### PR TITLE
Adds a gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+.ninja_deps
+.ninja_log
+build.ninja
+*.o
+*.pb.o
+torch2trt.egg-info
+build/
+dist/
+__pycache__/
+*.so
+*.pb.h
+*.pb.cc
+*_pb2.py


### PR DESCRIPTION
Adds a gitignore so that generated ninja, setuptools and protobuf files and directories aren't tracked

Signed-off-by: Naren Dasan <naren@narendasan.com>
Signed-off-by: Naren Dasan <narens@nvidia.com>