### PR TITLE
remove is_leaf checker

### DIFF
--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -124,7 +124,7 @@ def trt_(network, *tensors):
             trt_tensor = t._trt
             
         # or... add constant for leaf tensor w/o _trt
-        elif isinstance(t, torch.Tensor) and t.is_leaf and not hasattr(t, '_trt'):
+        elif isinstance(t, torch.Tensor) and not hasattr(t, '_trt'):
             # add leaf tensor
             shape = tuple(t.shape[1:])
             weight = t[0].detach().cpu().numpy()
@@ -136,7 +136,7 @@ def trt_(network, *tensors):
             shape = (1,) * broadcast_num_dim
             scalar = t * torch.ones(shape, dtype=dtype).cpu().numpy()
             trt_tensor = network.add_constant(shape, scalar).get_output(0)
-            
+         
         assert(trt_tensor is not None)#, 'TensorRT tensor could not be created')
             
         # MAKE TRT TENSOR BROADCASTABLE IF IT IS NOT ALREADY


### PR DESCRIPTION
I'd like to recommend removing `is_leaf` for learnable 'weight' tensor, which the tensor actually should be considered as leaf but it is not.
as mentioned in #82, `weight` can be used everywhere. For example, if you want to control `beta` mentioned in [retinaMask](https://arxiv.org/pdf/1901.03353.pdf) paper(see section 3.1: self-adjust smooth l1), it should possible to generate tensor._trt. Also, in this model [GAN](https://arxiv.org/pdf/1805.08318.pdf), they use learnable 'weight' parameter to control initial attention rate. Even Memory network, they abuse learnable weight parameter.

So, I hope this change not affect to model performance.