### PR TITLE
support Conv3d, batch_norm, Upsample, add warnings for DLL load

### DIFF
--- a/torch2trt/__init__.py
+++ b/torch2trt/__init__.py
@@ -1,3 +1,5 @@
+import warnings
+
 from .torch2trt import *
 from .converters import *
 import tensorrt as trt
@@ -17,5 +19,6 @@ def load_plugins():
 try:
     load_plugins()
     PLUGINS_LOADED = True
-except OSError:
+except OSError as e:
+    warnings.warn("load_plugins OSError: {}, set PLUGINS_LOADED to False".format(e), RuntimeWarning)
     PLUGINS_LOADED = False

--- a/torch2trt/converters/BatchNorm1d.py
+++ b/torch2trt/converters/BatchNorm1d.py
@@ -3,7 +3,7 @@ from torch2trt.module_test import add_module_test
 
 
 @tensorrt_converter('torch.nn.BatchNorm1d.forward')
-def convert_BatchNorm2d(ctx):
+def convert_BatchNorm1d(ctx):
     module = ctx.method_args[0]
     input = ctx.method_args[1]
     input_trt = trt_(ctx.network, input)

--- a/torch2trt/converters/BatchNorm2d.py
+++ b/torch2trt/converters/BatchNorm2d.py
@@ -1,4 +1,5 @@
 from torch2trt.torch2trt import *
+from torch2trt.module_test import add_module_test
 
 
 @tensorrt_converter('torch.nn.BatchNorm2d.forward')
@@ -15,3 +16,8 @@ def convert_BatchNorm2d(ctx):
     layer = ctx.network.add_scale(input_trt, trt.ScaleMode.CHANNEL, bias, scale, power)
 
     output._trt = layer.get_output(0)
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 10, 10, 10)])
+def test_BatchNorm2d_basic():
+    return torch.nn.BatchNorm2d(10)

--- a/torch2trt/converters/Conv3d.py
+++ b/torch2trt/converters/Conv3d.py
@@ -1,0 +1,68 @@
+from torch2trt.module_test import add_module_test
+from torch2trt.torch2trt import *
+
+
+@tensorrt_converter("torch.nn.Conv3d.forward")
+def convert_Conv3d(ctx):
+    module = ctx.method_args[0]
+    input = ctx.method_args[1]
+    input_trt = trt_(ctx.network, input)
+    output = ctx.method_return
+
+    kernel_size = module.kernel_size
+    if not isinstance(kernel_size, tuple):
+        kernel_size = (kernel_size,) * 3
+
+    stride = module.stride
+    if not isinstance(stride, tuple):
+        stride = (stride,) * 3
+
+    padding = module.padding
+    if not isinstance(padding, tuple):
+        padding = (padding,) * 3
+
+    dilation = module.dilation
+    if not isinstance(dilation, tuple):
+        dilation = (dilation,) * 3
+
+    kernel = module.weight.detach().cpu().numpy()
+
+    bias = trt.Weights(torch_dtype_to_trt(module.weight.dtype))
+    if module.bias is not None:
+        bias = module.bias.detach().cpu().numpy()
+
+    layer = ctx.network.add_convolution_nd(
+        input=input_trt,
+        num_output_maps=module.out_channels,
+        kernel_shape=kernel_size,
+        kernel=kernel,
+        bias=bias,
+    )
+    layer.stride_nd = stride
+    layer.padding_nd = padding
+    layer.dilation_nd = dilation
+
+    if module.groups is not None:
+        layer.num_groups = module.groups
+
+    output._trt = layer.get_output(0)
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 10, 128, 128, 128)])
+def test_Conv3d_basic():
+    return torch.nn.Conv3d(10, 5, kernel_size=1, stride=1, padding=0)
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 10, 128, 128, 128)])
+def test_Conv3d_stride2():
+    return torch.nn.Conv3d(10, 5, kernel_size=1, stride=2, padding=0)
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 10, 128, 128, 128)])
+def test_Conv3d_kernel3():
+    return torch.nn.Conv3d(10, 5, kernel_size=3, stride=2, padding=1)
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 10, 128, 128, 128)])
+def test_Conv3d_dilation2():
+    return torch.nn.Conv3d(10, 5, kernel_size=3, stride=1, padding=1, dilation=2)

--- a/torch2trt/converters/Upsample.py
+++ b/torch2trt/converters/Upsample.py
@@ -1,0 +1,89 @@
+from torch2trt.module_test import add_module_test
+from torch2trt.torch2trt import *
+
+
+@tensorrt_converter("torch.nn.Upsample.forward")
+def convert_batch_norm(ctx):
+    module = ctx.method_args[0]
+
+    # only support `nearest` or `linear` and align_corners=True
+    assert (
+        module.mode == "nearest"
+        or module.mode.endswith("linear")
+        and module.align_corners
+    )
+
+    input = ctx.method_args[1]
+    input_trt = trt_(ctx.network, input)
+    output = ctx.method_return
+
+    layer = ctx.network.add_resize(input_trt)
+    layer.shape = list(output.shape[1:])
+    layer.resize_mode = (
+        trt.ResizeMode.NEAREST if module.mode == "nearest" else trt.ResizeMode.LINEAR
+    )
+    layer.align_corners = module.align_corners
+
+    output._trt = layer.get_output(0)
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 32, 64)])
+def test_Upsample_1d_size():
+    return torch.nn.Upsample(size=100)
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 32, 64)])
+def test_Upsample_1d_size_linear():
+    return torch.nn.Upsample(size=100, mode="linear", align_corners=True)
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 32, 64)])
+def test_Upsample_1d_scale():
+    return torch.nn.Upsample(scale_factor=1.7)
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 32, 64)])
+def test_Upsample_1d_scale_linear():
+    return torch.nn.Upsample(scale_factor=1.7, mode="linear", align_corners=True)
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 32, 64, 128)])
+def test_Upsample_2d_size():
+    return torch.nn.Upsample(size=(100, 256))
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 32, 64, 128)])
+def test_Upsample_2d_size_linear():
+    return torch.nn.Upsample(size=(100, 256), mode="bilinear", align_corners=True)
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 32, 64, 128)])
+def test_Upsample_2d_scale():
+    return torch.nn.Upsample(scale_factor=(1.7, 2))
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 32, 64, 128)])
+def test_Upsample_2d_scale_linear():
+    return torch.nn.Upsample(scale_factor=(1.7, 2), mode="bilinear", align_corners=True)
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 16, 32, 64, 64)])
+def test_Upsample_3d_size():
+    return torch.nn.Upsample(size=(48, 100, 128))
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 16, 32, 64, 64)])
+def test_Upsample_3d_size_linear():
+    return torch.nn.Upsample(size=(48, 100, 128), mode="trilinear", align_corners=True)
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 16, 32, 64, 64)])
+def test_Upsample_3d_scale():
+    return torch.nn.Upsample(scale_factor=(1.3, 1.7, 2))
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 16, 32, 64, 64)])
+def test_Upsample_3d_scale_linear():
+    return torch.nn.Upsample(
+        scale_factor=(1.3, 1.7, 2), mode="trilinear", align_corners=True
+    )

--- a/torch2trt/converters/__init__.py
+++ b/torch2trt/converters/__init__.py
@@ -42,6 +42,7 @@ from .split import *
 from .chunk import *
 from .unary import *
 from .batch_norm import *
+from .Upsample import *
 
 
 try:

--- a/torch2trt/converters/__init__.py
+++ b/torch2trt/converters/__init__.py
@@ -41,6 +41,7 @@ from .softmax import *
 from .split import *
 from .chunk import *
 from .unary import *
+from .batch_norm import *
 
 
 try:

--- a/torch2trt/converters/__init__.py
+++ b/torch2trt/converters/__init__.py
@@ -11,6 +11,7 @@ from .cat import *
 from .clamp import *
 from .Conv1d import *
 from .Conv2d import *
+from .Conv3d import *
 from .ConvTranspose2d import *
 from .identity import *
 from .Identity import *

--- a/torch2trt/converters/add.py
+++ b/torch2trt/converters/add.py
@@ -3,6 +3,8 @@ from torch2trt.module_test import add_module_test
 
 
 @tensorrt_converter('torch.add')
+@tensorrt_converter('torch.Tensor.add')
+@tensorrt_converter('torch.Tensor.add_')
 @tensorrt_converter('torch.Tensor.__iadd__')
 @tensorrt_converter('torch.Tensor.__add__')
 @tensorrt_converter('torch.Tensor.__radd__')
@@ -13,7 +15,33 @@ def convert_add(ctx):
     output = ctx.method_return
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, trt.ElementWiseOperation.SUM)
     output._trt = layer.get_output(0)
-    
+
+
+class TensorAdd(torch.nn.Module):
+    def __init__(self):
+        super(TensorAdd, self).__init__()
+
+    def forward(self, x, y):
+        return x.add(y)
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 224, 224), (1, 3, 224, 224)])
+def test_tensor_add():
+    return TensorAdd()
+
+
+class TensorAdd_(torch.nn.Module):
+    def __init__(self):
+        super(TensorAdd_, self).__init__()
+
+    def forward(self, x, y):
+        return x.add_(y)
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 224, 224), (1, 3, 224, 224)])
+def test_tensor_add_():
+    return TensorAdd()
+
 
 class Add(torch.nn.Module):
     def __init__(self):
@@ -21,6 +49,7 @@ class Add(torch.nn.Module):
 
     def forward(self, x, y):
         return x + y
+
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 224, 224), (1, 3, 224, 224)])
 def test_add_basic():

--- a/torch2trt/converters/batch_norm.py
+++ b/torch2trt/converters/batch_norm.py
@@ -1,0 +1,40 @@
+from torch2trt.module_test import add_module_test
+from torch2trt.torch2trt import *
+
+
+@tensorrt_converter("torch.nn.functional.batch_norm")
+@tensorrt_converter("torch.batch_norm")
+def convert_batch_norm(ctx):
+    input = ctx.method_args[0]
+    input_trt = trt_(ctx.network, input)
+    output = ctx.method_return
+
+    scale = ctx.method_args[3].detach().cpu().numpy() / np.sqrt(
+        ctx.method_args[2].detach().cpu().numpy() + ctx.method_args[7]
+    )
+    bias = (
+        ctx.method_args[4].detach().cpu().numpy()
+        - ctx.method_args[1].detach().cpu().numpy() * scale
+    )
+    power = np.ones_like(scale)
+
+    layer = ctx.network.add_scale_nd(
+        input_trt, trt.ScaleMode.CHANNEL, bias, scale, power, 0
+    )
+
+    output._trt = layer.get_output(0)
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 10, 5)])
+def test_batch_norm_1d():
+    return torch.nn.BatchNorm1d(10)
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 10, 5, 5)])
+def test_batch_norm_2d():
+    return torch.nn.BatchNorm2d(10)
+
+
+@add_module_test(torch.float32, torch.device("cuda"), [(1, 10, 5, 5, 5)])
+def test_batch_norm_3d():
+    return torch.nn.BatchNorm3d(10)


### PR DESCRIPTION
add converter for Conv3d, and pass the test:

`python -m torch2trt.test --name=Conv3d`

| Name | Data Type | Input Shapes | torch2trt kwargs | Max Error | Throughput (PyTorch) | Throughput (TensorRT) | Latency (PyTorch) | Latency (TensorRT) |
|------|-----------|--------------|------------------|-----------|----------------------|-----------------------|-------------------|--------------------|
| torch2trt.converters.Conv3d.test_Conv3d_basic | float32 | [(1, 10, 128, 128, 128)] | {} | 0.00E+00 | 37.3 | 33.1 | 26.6 | 30.3 |
| torch2trt.converters.Conv3d.test_Conv3d_stride2 | float32 | [(1, 10, 128, 128, 128)] | {} | 0.00E+00 | 295 | 263 | 3.44 | 3.86 |
| torch2trt.converters.Conv3d.test_Conv3d_kernel3 | float32 | [(1, 10, 128, 128, 128)] | {} | 2.26E-06 | 46.9 | 28.6 | 21.6 | 35 |
| torch2trt.converters.Conv3d.test_Conv3d_dilation2 | float32 | [(1, 10, 128, 128, 128)] | {} | 0.00E+00 | 3.71 | 3.7 | 271 | 271 |

`python -m torch2trt.test --name=batch_norm`

| Name | Data Type | Input Shapes | torch2trt kwargs | Max Error | Throughput (PyTorch) | Throughput (TensorRT) | Latency (PyTorch) | Latency (TensorRT) |
|------|-----------|--------------|------------------|-----------|----------------------|-----------------------|-------------------|--------------------|
| torch2trt.converters.batch_norm.test_batch_norm_1d | float32 | [(1, 10, 5)] | {} | 1.19E-07 | 1.57e+04 | 7.33e+03 | 0.0953 | 0.149 |
| torch2trt.converters.batch_norm.test_batch_norm_2d | float32 | [(1, 10, 5, 5)] | {} | 2.38E-07 | 3.09e+04 | 2.02e+04 | 0.0448 | 0.0565 |
| torch2trt.converters.batch_norm.test_batch_norm_3d | float32 | [(1, 10, 5, 5, 5)] | {} | 2.38E-07 | 3.41e+04 | 1.97e+04 | 0.0477 | 0.0626 |

`python -m torch2trt.test --name=Upsample`

| Name | Data Type | Input Shapes | torch2trt kwargs | Max Error | Throughput (PyTorch) | Throughput (TensorRT) | Latency (PyTorch) | Latency (TensorRT) |
|------|-----------|--------------|------------------|-----------|----------------------|-----------------------|-------------------|--------------------|
| torch2trt.converters.Upsample.test_Upsample_1d_size | float32 | [(1, 32, 64)] | {} | 0.00E+00 | 4.63e+04 | 2.16e+04 | 0.0364 | 0.0553 |
| torch2trt.converters.Upsample.test_Upsample_1d_size_linear | float32 | [(1, 32, 64)] | {} | 2.38E-07 | 2.44e+04 | 1.85e+04 | 0.0754 | 0.0575 |
| torch2trt.converters.Upsample.test_Upsample_1d_scale | float32 | [(1, 32, 64)] | {} | 0.00E+00 | 1.58e+04 | 7.43e+03 | 0.12 | 0.162 |
| torch2trt.converters.Upsample.test_Upsample_1d_scale_linear | float32 | [(1, 32, 64)] | {} | 2.38E-07 | 2.2e+04 | 1.22e+04 | 0.137 | 0.109 |
| torch2trt.converters.Upsample.test_Upsample_2d_size | float32 | [(1, 32, 64, 128)] | {} | 0.00E+00 | 2.55e+03 | 968 | 0.411 | 0.988 |
| torch2trt.converters.Upsample.test_Upsample_2d_size_linear | float32 | [(1, 32, 64, 128)] | {} | 4.26E-05 | 3.32e+03 | 1.04e+03 | 0.323 | 0.951 |
| torch2trt.converters.Upsample.test_Upsample_2d_scale | float32 | [(1, 32, 64, 128)] | {} | 0.00E+00 | 2.93e+03 | 1.1e+03 | 0.369 | 0.916 |
| torch2trt.converters.Upsample.test_Upsample_2d_scale_linear | float32 | [(1, 32, 64, 128)] | {} | 4.03E-05 | 3.49e+03 | 1.24e+03 | 0.314 | 0.857 |
| torch2trt.converters.Upsample.test_Upsample_3d_size | float32 | [(1, 16, 32, 64, 64)] | {} | 0.00E+00 | 53.5 | 102 | 18.8 | 10.1 |
| torch2trt.converters.Upsample.test_Upsample_3d_size_linear | float32 | [(1, 16, 32, 64, 64)] | {} | 7.15E-07 | 165 | 101 | 5.72 | 9.61 |
| torch2trt.converters.Upsample.test_Upsample_3d_scale | float32 | [(1, 16, 32, 64, 64)] | {} | 0.00E+00 | 57.6 | 111 | 17.4 | 9.15 |
| torch2trt.converters.Upsample.test_Upsample_3d_scale_linear | float32 | [(1, 16, 32, 64, 64)] | {} | 2.22E-05 | 178 | 108 | 5.33 | 8.91 |