### PR TITLE
Int8 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ class CleanCommand(Command):
 
 setup(
     name='torch2trt',
-    version='0.0.2',
+    version='0.0.3',
     description='An easy to use PyTorch to TensorRT converter',
     cmdclass={
         'install': InstallCommand,

--- a/torch2trt/calibration.py
+++ b/torch2trt/calibration.py
@@ -16,20 +16,17 @@ class TensorBatchDataset():
     
 class DatasetCalibrator(trt.IInt8Calibrator):
     
-    def __init__(self, dataset, batch_size=1, algorithm=trt.CalibrationAlgoType.ENTROPY_CALIBRATION_2):
+    def __init__(self, inputs, dataset, batch_size=1, algorithm=trt.CalibrationAlgoType.ENTROPY_CALIBRATION_2):
         super().__init__()
         
         self.dataset = dataset
         self.batch_size = batch_size
         self.algorithm = algorithm
         
-        # pull sample, should not include batch dimension
-        inputs = dataset[0] 
-        
         # create buffers that will hold data batches
         self.buffers = []
         for tensor in inputs:
-            size = (batch_size,) + tuple(tensor.shape)
+            size = (batch_size,) + tuple(tensor.shape[1:])
             buf = torch.zeros(size=size, dtype=tensor.dtype, device=tensor.device).contiguous()
             self.buffers.append(buf)
             

--- a/torch2trt/calibration.py
+++ b/torch2trt/calibration.py
@@ -23,7 +23,7 @@ class TensorBatchDataset():
 class DatasetCalibrator(trt.IInt8Calibrator):
     
     def __init__(self, inputs, dataset, batch_size=1, algorithm=DEFAULT_CALIBRATION_ALGORITHM):
-        super().__init__()
+        super(DatasetCalibrator, self).__init__()
         
         self.dataset = dataset
         self.batch_size = batch_size

--- a/torch2trt/calibration.py
+++ b/torch2trt/calibration.py
@@ -47,8 +47,8 @@ class DatasetCalibrator(trt.IInt8Calibrator):
                 inputs = self.dataset[idx]
                 
                 # copy data for (input_idx, dataset_idx) into buffer
-                for j, tensor in enumerate(inputs):
-                    self.buffers[j][i].copy_(tensor)
+                for buffer, tensor in zip(self.buffers, inputs):
+                    buffer[i].copy_(tensor)
                 
                 self.count += 1
                 

--- a/torch2trt/calibration.py
+++ b/torch2trt/calibration.py
@@ -26,11 +26,11 @@ class DatasetCalibrator(trt.IInt8Calibrator):
         # pull sample, should not include batch dimension
         inputs = dataset[0] 
         
-        # create buffers that will hold random data batches
+        # create buffers that will hold data batches
         self.buffers = []
         for tensor in inputs:
             size = (batch_size,) + tuple(tensor.shape)
-            buf = torch.randn(size=size, dtype=tensor.dtype, device=tensor.device).contiguous()
+            buf = torch.zeros(size=size, dtype=tensor.dtype, device=tensor.device).contiguous()
             self.buffers.append(buf)
             
         self.count = 0
@@ -43,6 +43,7 @@ class DatasetCalibrator(trt.IInt8Calibrator):
                 idx = self.count % len(self.dataset) # roll around if not multiple of dataset
                 inputs = self.dataset[idx]
                 
+                # copy data for (input_idx, dataset_idx) into buffer
                 for j, tensor in enumerate(inputs):
                     self.buffers[j][i].copy_(tensor)
                 

--- a/torch2trt/calibration.py
+++ b/torch2trt/calibration.py
@@ -2,6 +2,12 @@ import torch
 import tensorrt as trt
 
 
+if trt.__version__ >= '5.1':
+    DEFAULT_CALIBRATION_ALGORITHM = trt.CalibrationAlgoType.ENTROPY_CALIBRATION_2
+else:
+    DEFAULT_CALIBRATION_ALGORITHM = trt.CalibrationAlgoType.ENTROPY_CALIBRATION
+    
+
 class TensorBatchDataset():
     
     def __init__(self, tensors):
@@ -16,7 +22,7 @@ class TensorBatchDataset():
     
 class DatasetCalibrator(trt.IInt8Calibrator):
     
-    def __init__(self, inputs, dataset, batch_size=1, algorithm=trt.CalibrationAlgoType.ENTROPY_CALIBRATION_2):
+    def __init__(self, inputs, dataset, batch_size=1, algorithm=DEFAULT_CALIBRATION_ALGORITHM):
         super().__init__()
         
         self.dataset = dataset
@@ -56,8 +62,8 @@ class DatasetCalibrator(trt.IInt8Calibrator):
     def get_batch_size(self):
         return self.batch_size
     
-    def read_calibration_cache(self):
+    def read_calibration_cache(self, *args, **kwargs):
         return None
     
-    def write_calibration_cache(self, cache):
+    def write_calibration_cache(self, cache, *args, **kwargs):
         pass

--- a/torch2trt/calibration.py
+++ b/torch2trt/calibration.py
@@ -1,0 +1,65 @@
+import torch
+import tensorrt as trt
+
+
+class TensorBatchDataset():
+    
+    def __init__(self, tensors):
+        self.tensors = tensors
+    
+    def __len__(self):
+        return len(self.tensors[0])
+    
+    def __getitem__(self, idx):
+        return [t[idx] for t in self.tensors]
+    
+    
+class DatasetCalibrator(trt.IInt8Calibrator):
+    
+    def __init__(self, dataset, batch_size=1, algorithm=trt.CalibrationAlgoType.ENTROPY_CALIBRATION_2):
+        super().__init__()
+        
+        self.dataset = dataset
+        self.batch_size = batch_size
+        self.algorithm = algorithm
+        
+        # pull sample, should not include batch dimension
+        inputs = dataset[0] 
+        
+        # create buffers that will hold random data batches
+        self.buffers = []
+        for tensor in inputs:
+            size = (batch_size,) + tuple(tensor.shape)
+            buf = torch.randn(size=size, dtype=tensor.dtype, device=tensor.device).contiguous()
+            self.buffers.append(buf)
+            
+        self.count = 0
+        
+    def get_batch(self, *args, **kwargs):
+        if self.count < len(self.dataset):
+            
+            for i in range(self.batch_size):
+                
+                idx = self.count % len(self.dataset) # roll around if not multiple of dataset
+                inputs = self.dataset[idx]
+                
+                for j, tensor in enumerate(inputs):
+                    self.buffers[j][i].copy_(tensor)
+                
+                self.count += 1
+                
+            return [int(buf.data_ptr()) for buf in self.buffers]
+        else:
+            return []
+        
+    def get_algorithm(self):
+        return self.algorithm
+    
+    def get_batch_size(self):
+        return self.batch_size
+    
+    def read_calibration_cache(self):
+        return None
+    
+    def write_calibration_cache(self, cache):
+        pass

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -357,6 +357,8 @@ def torch2trt(module,
               int8_calib_dataset=None,
               int8_calib_algorithm=trt.CalibrationAlgoType.ENTROPY_CALIBRATION_2):
 
+    inputs_in = inputs
+    
     # copy inputs to avoid modifications to source data
     inputs = [tensor.clone()[0:1] for tensor in inputs]  # only run single entry
     
@@ -387,12 +389,12 @@ def torch2trt(module,
         
         # default to use input tensors for calibration
         if int8_calib_dataset is None:
-            int8_calib_dataset = TensorBatchDataset(inputs)
+            int8_calib_dataset = TensorBatchDataset(inputs_in)
         
         builder.int8_mode = True
         
         # @TODO(jwelsh):  Should we set batch_size=max_batch_size?  Need to investigate memory consumption
-        builder.int8_calibrator = DatasetCalibrator(int8_calib_dataset, batch_size=1, algorithm=int8_calib_algorithm)
+        builder.int8_calibrator = DatasetCalibrator(inputs, int8_calib_dataset, batch_size=1, algorithm=int8_calib_algorithm)
 
     engine = builder.build_cuda_engine(network)
     

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -2,7 +2,7 @@ import torch
 import tensorrt as trt
 from copy import copy
 import numpy as np
-from .calibration import TensorBatchDataset, DatasetCalibrator
+from .calibration import TensorBatchDataset, DatasetCalibrator, DEFAULT_CALIBRATION_ALGORITHM
 
 
 # UTILITY FUNCTIONS
@@ -355,7 +355,7 @@ def torch2trt(module,
               keep_network=True, 
               int8_mode=False, 
               int8_calib_dataset=None,
-              int8_calib_algorithm=trt.CalibrationAlgoType.ENTROPY_CALIBRATION_2):
+              int8_calib_algorithm=DEFAULT_CALIBRATION_ALGORITHM):
 
     inputs_in = inputs
     


### PR DESCRIPTION
Adds support for int8 calibration

## Usage

### Calibrate using inputs (Small data)

This shows basic usage where the calibration data is inferred from input data.  This will calibrate on 8 random normal samples.  

> Please note, the inference batch size remains whatever is set with ``max_batch_size`` parameter.

```python
data = torch.randn(8, 3, 224, 224).cuda()

model = torchvision.models.resnet18(pretrained=False).cuda().eval()

model_trt = torch2trt(model, [data], int8_mode=True)
```

### Calibrate using dataset (Big data)

Sometimes, the calibration data may be larger than can fit in memory.  In this case, you can provide a dataset class that implements the ``__len__`` and ``__getitem__`` methods.   Below we will implement a calibration dataset that functions similar to Example 1, but using the dataset method.

First, define the dataset

```python
class RandomDataset(object):

    def __len__(self):
        return 8

    def __getitem__(self, idx):
        return [ torch.randn(3, 224, 224) ]
```

Internally, the shape, device, and data type of calibration data will be inferred from the ``inputs`` parameter.  So it is OK if the tensors returned by ``__getitem__`` live on CPU/GPU or include/exclude the batch dimension.  It is important that the items returned by ``__getitem__`` have the correct shape and order of inputs in the case of multiple input nodes.

```python
dataset = RandomDataset()

model_trt = torch2trt(model, [data], int8_mode=True, int8_calib_dataset=dataset)
```

### Calibration algorithm

You may set the calibration algorithm, [see this](https://docs.nvidia.com/deeplearning/sdk/tensorrt-api/python_api/infer/Int8/Calibrator.html).

```python
model_trt = torch2trt(model, [data], int8_mode=True, int8_calib_algorithm=trt.CalibrationAlgoType.ENTROPY_CALIBRATION_2)
```