### PR TITLE
Support Layer: nn.Flatten()

### DIFF
--- a/torch2trt/converters/view.py
+++ b/torch2trt/converters/view.py
@@ -3,6 +3,7 @@ from torch2trt.module_test import add_module_test
 
 
 @tensorrt_converter('torch.flatten')
+@tensorrt_converter('torch.Tensor.flatten')
 @tensorrt_converter('torch.Tensor.reshape')
 @tensorrt_converter('torch.Tensor.view')
 def convert_view(ctx):


### PR DESCRIPTION
Add support for the new PyTorch layer nn.Flatten() and remove warning messages currently showed when used.

Let me know if you need more details but a very minor one. Figure it will be straightforward.