### PR TITLE
fix padding issue of 2d transposed conv.

### DIFF
--- a/torch2trt/converters/ConvTranspose2d.py
+++ b/torch2trt/converters/ConvTranspose2d.py
@@ -33,6 +33,13 @@ def convert_ConvTranspose2d(ctx):
         kernel=kernel,
         bias=bias)
     layer.stride = stride
+
+    # if output_padding in original pytorch layer is not 0, pre_padding and post_padding should be set respectively. Otherwise the output dimension of pytorch and tensorrt may be different.
+    output_padding = module.output_padding
+    if output_padding[0] + output_padding[1] > 0:
+        layer.pre_padding = padding
+        layer.post_padding = trt.tensorrt.DimsHW(padding[0] - output_padding[0], padding[1] - output_padding[1])
+    else:
     layer.padding = padding
     
     if module.groups is not None:


### PR DESCRIPTION
In pytorch, ConvTranspose2d has 2 padding related parameters, which are padding and output_padding. In tensorrt, there are 3 padding related parameters in IDeconvolutionLayer, which are pre_padding, padding and post_padding, when the parameter padding is assigned, pre_padding and post_padding are aotomatically assigned with the same value.
When the output_padding in pytorch is 0, the converter works fine. But when the output_padding is not 0, then the pre_padding parameter in tensorrt should be the padding parameter in pytorch, the post_padding parameter should be (layer_in_pytorch.padding - layer_in_pytorch.output_padding),