### PR TITLE
Const dim fix

### DIFF
--- a/torch2trt/converters/AdaptiveAvgPool2d.py
+++ b/torch2trt/converters/AdaptiveAvgPool2d.py
@@ -8,7 +8,7 @@ def convert_AdaptiveAvgPool2d(ctx):
     input = ctx.method_args[1]
     output = ctx.method_return
     
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
 
     output_size = module.output_size
     if not isinstance(output_size, tuple):

--- a/torch2trt/converters/BatchNorm1d.py
+++ b/torch2trt/converters/BatchNorm1d.py
@@ -6,7 +6,7 @@ from torch2trt.module_test import add_module_test
 def convert_BatchNorm2d(ctx):
     module = ctx.method_args[0]
     input = ctx.method_args[1]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     
     scale = module.weight.detach().cpu().numpy() / np.sqrt(module.running_var.detach().cpu().numpy() + module.eps)

--- a/torch2trt/converters/BatchNorm2d.py
+++ b/torch2trt/converters/BatchNorm2d.py
@@ -6,7 +6,7 @@ from torch2trt.module_test import add_module_test
 def convert_BatchNorm2d(ctx):
     module = ctx.method_args[0]
     input = ctx.method_args[1]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
 
     scale = module.weight.detach().cpu().numpy() / np.sqrt(

--- a/torch2trt/converters/Conv.py
+++ b/torch2trt/converters/Conv.py
@@ -7,7 +7,7 @@ from torch2trt.module_test import add_module_test
 def convert_Conv_trt7(ctx):
     module = ctx.method_args[0]
     input = ctx.method_args[1]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
 
     input_dim = input.dim() - 2

--- a/torch2trt/converters/Conv1d.py
+++ b/torch2trt/converters/Conv1d.py
@@ -6,7 +6,7 @@ from torch2trt.module_test import add_module_test
 def convert_Conv1d(ctx):
     module = ctx.method_args[0]
     input = ctx.method_args[1]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
 
     kernel_size = (module.kernel_size[0], 1)

--- a/torch2trt/converters/Conv2d.py
+++ b/torch2trt/converters/Conv2d.py
@@ -6,7 +6,7 @@ from torch2trt.module_test import add_module_test
 def convert_Conv2d(ctx):
     module = ctx.method_args[0]
     input = ctx.method_args[1]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
 
     kernel_size = module.kernel_size

--- a/torch2trt/converters/ConvTranspose.py
+++ b/torch2trt/converters/ConvTranspose.py
@@ -7,7 +7,7 @@ from torch2trt.module_test import add_module_test
 def convert_ConvTranspose2d_trt7(ctx):
     module = ctx.method_args[0]
     input = ctx.method_args[1]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
 
     input_dim = input.dim() - 2

--- a/torch2trt/converters/ConvTranspose2d.py
+++ b/torch2trt/converters/ConvTranspose2d.py
@@ -5,7 +5,7 @@ from torch2trt.module_test import add_module_test
 def convert_ConvTranspose2d(ctx):
     module = ctx.method_args[0]
     input = ctx.method_args[1]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
 
     kernel_size = module.kernel_size

--- a/torch2trt/converters/Identity.py
+++ b/torch2trt/converters/Identity.py
@@ -6,6 +6,6 @@ from torch2trt.torch2trt import *
 @tensorrt_converter('torch.nn.Dropout3d.forward')
 def convert_Identity(ctx):
     input = ctx.method_args[1]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     output._trt = input_trt

--- a/torch2trt/converters/Linear.py
+++ b/torch2trt/converters/Linear.py
@@ -6,7 +6,7 @@ from torch2trt.module_test import add_module_test
 def convert_Linear(ctx):
     module = ctx.method_args[0]
     input = ctx.method_args[1]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
 
     # reshape to ...xNx1x1

--- a/torch2trt/converters/LogSoftmax.py
+++ b/torch2trt/converters/LogSoftmax.py
@@ -4,7 +4,7 @@ from torch2trt.torch2trt import *
 @tensorrt_converter('torch.nn.LogSoftmax.forward')
 def convert_LogSoftmax(ctx):
     input = ctx.method_args[1]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     layer = ctx.network.add_softmax(input=input_trt)
     layer = ctx.network.add_unary(input=layer.get_output(0),

--- a/torch2trt/converters/ReLU.py
+++ b/torch2trt/converters/ReLU.py
@@ -4,7 +4,7 @@ from torch2trt.torch2trt import *
 @tensorrt_converter('torch.nn.ReLU.forward')
 def convert_ReLU(ctx):
     input = ctx.method_args[1]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     layer = ctx.network.add_activation(
         input=input_trt, type=trt.ActivationType.RELU)

--- a/torch2trt/converters/ReLU6.py
+++ b/torch2trt/converters/ReLU6.py
@@ -7,12 +7,13 @@ def convert_ReLU6(ctx):
     input = ctx.method_args[1]
     output = ctx.method_return
     
-    input_trt, trt_6 = trt_(ctx.network, input, 6)
+    input_a_trt, input_b_trt = add_missing_trt_tensors(ctx.network, [input, 6])
+    input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], output.ndim - 1)
 
     layer = ctx.network.add_activation(
-        input=input_trt, type=trt.ActivationType.RELU)
+        input=input_a_trt, type=trt.ActivationType.RELU)
     layer = ctx.network.add_elementwise(
-        layer.get_output(0), trt_6, trt.ElementWiseOperation.MIN)
+        layer.get_output(0), input_b_trt, trt.ElementWiseOperation.MIN)
 
     output._trt = layer.get_output(0)
     

--- a/torch2trt/converters/activation.py
+++ b/torch2trt/converters/activation.py
@@ -18,7 +18,7 @@ def convert_leaky_relu(ctx):
     negative_slope = get_arg(ctx, 'negative_slope', pos=1, default=0.01)
     output = ctx.method_return
     
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     layer = ctx.network.add_activation(input_trt, trt.ActivationType.LEAKY_RELU)
     layer.alpha = negative_slope
     
@@ -40,7 +40,7 @@ def convert_elu(ctx):
     alpha = get_arg(ctx, 'alpha', pos=1, default=1.0)
     output = ctx.method_return
     
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     layer = ctx.network.add_activation(input_trt, trt.ActivationType.ELU)
     layer.alpha = alpha
     
@@ -63,7 +63,7 @@ def convert_selu(ctx):
     alpha = get_arg(ctx, 'alpha', pos=1, default=1.0)
     output = ctx.method_return
     
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     layer = ctx.network.add_activation(input_trt, trt.ActivationType.SELU)
     layer.alpha = 1.6732632423543772848170429916717
     layer.beta = 1.0507009873554804934193349852946
@@ -84,7 +84,7 @@ def convert_softsign(ctx):
     input = get_arg(ctx, 'input', pos=0, default=None)
     output = ctx.method_return
     
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     layer = ctx.network.add_activation(input_trt, trt.ActivationType.SOFTSIGN)
     
     output._trt = layer.get_output(0)
@@ -103,7 +103,7 @@ def convert_softplus(ctx):
     input = get_arg(ctx, 'input', pos=0, default=None)
     output = ctx.method_return
     
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     layer = ctx.network.add_activation(input_trt, trt.ActivationType.SOFTPLUS)
     
     output._trt = layer.get_output(0)

--- a/torch2trt/converters/add.py
+++ b/torch2trt/converters/add.py
@@ -9,8 +9,9 @@ from torch2trt.module_test import add_module_test
 def convert_add(ctx):
     input_a = ctx.method_args[0]
     input_b = ctx.method_args[1]
-    input_a_trt, input_b_trt = trt_(ctx.network, input_a, input_b)
     output = ctx.method_return
+    input_a_trt, input_b_trt = add_missing_trt_tensors(ctx.network, [input_a, input_b])
+    input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], output.ndim - 1)
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, trt.ElementWiseOperation.SUM)
     output._trt = layer.get_output(0)
     

--- a/torch2trt/converters/add.py
+++ b/torch2trt/converters/add.py
@@ -79,3 +79,31 @@ class RAddFloat(torch.nn.Module):
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 224, 224)])
 def test_add_radd_float():
     return RAddFloat()
+
+
+class AddConstantNoBatch(torch.nn.Module):
+    def __init__(self):
+        super(AddConstantNoBatch, self).__init__()
+        self.register_buffer('y', torch.ones((3, 10, 10)))
+
+    def forward(self, x):
+        return x + self.y
+
+    
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 10, 10)])
+def test_add_constant_nobatch():
+    return AddConstantNoBatch()
+
+
+class AddConstantBatch(torch.nn.Module):
+    def __init__(self):
+        super(AddConstantBatch, self).__init__()
+        self.register_buffer('y', torch.ones((1, 3, 10, 10)))
+
+    def forward(self, x):
+        return x + self.y
+
+    
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 10, 10)])
+def test_add_constant_batch():
+    return AddConstantBatch()

--- a/torch2trt/converters/avg_pool.py
+++ b/torch2trt/converters/avg_pool.py
@@ -13,7 +13,7 @@ def convert_avg_pool2d(ctx):
     count_include_pad = get_arg(ctx, "count_include_pad", pos=5, default=True)
 
     # get input trt tensor (or create constant if it doesn't exist)
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
 
     output = ctx.method_return
 
@@ -55,7 +55,7 @@ def convert_avg_pool_trt7(ctx):
     count_include_pad = get_arg(ctx, 'count_include_pad', pos=5, default=True)
     
     # get input trt tensor (or create constant if it doesn't exist)
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
 
     input_dim = input.dim() - 2

--- a/torch2trt/converters/batch_norm.py
+++ b/torch2trt/converters/batch_norm.py
@@ -12,7 +12,7 @@ def convert_batch_norm_trt7(ctx):
     bias = get_arg(ctx, 'bias', pos=4, default=None) 
     eps = get_arg(ctx, 'eps', pos=7, default=10e-6) 
 
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     
     scale = weight.detach().cpu().numpy() / np.sqrt(running_var.detach().cpu().numpy() + eps)

--- a/torch2trt/converters/cat.py
+++ b/torch2trt/converters/cat.py
@@ -8,7 +8,8 @@ def convert_cat(ctx):
     dim = get_arg(ctx, 'dim', pos=1, default=0) 
 
     output = ctx.method_return
-    trt_inputs = [trt_(ctx.network, i) for i in inputs]
+    trt_inputs = add_missing_trt_tensors(ctx.network, inputs)
+    trt_inputs = broadcast_trt_tensors(ctx.network, trt_inputs, output.ndim - 1)
 
     layer = ctx.network.add_concatenation(inputs=trt_inputs)
     layer.axis = dim - 1

--- a/torch2trt/converters/compare.py
+++ b/torch2trt/converters/compare.py
@@ -4,8 +4,9 @@ from torch2trt.module_test import add_module_test
 def convert_elementwise(ctx, op):
     input_a = ctx.method_args[0]
     input_b = ctx.method_args[1]
-    input_a_trt, input_b_trt = trt_(ctx.network, input_a, input_b)
     output = ctx.method_return
+    input_a_trt, input_b_trt = add_missing_trt_tensors(ctx.network, [input_a, input_b])
+    input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], output.ndim - 1)
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, op)
     output._trt = layer.get_output(0)
 

--- a/torch2trt/converters/div.py
+++ b/torch2trt/converters/div.py
@@ -10,8 +10,9 @@ from torch2trt.module_test import add_module_test
 def convert_div(ctx):
     input_a = ctx.method_args[0]
     input_b = ctx.method_args[1]
-    input_a_trt, input_b_trt = trt_(ctx.network, input_a, input_b)
     output = ctx.method_return
+    input_a_trt, input_b_trt = add_missing_trt_tensors(ctx.network, [input_a, input_b])
+    input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], output.ndim - 1)
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, trt.ElementWiseOperation.DIV)
     output._trt = layer.get_output(0)
 
@@ -21,8 +22,9 @@ def convert_div(ctx):
 def convert_rdiv(ctx):
     input_a = ctx.method_args[1]  # inputs switched for rdiv
     input_b = ctx.method_args[0]
-    input_a_trt, input_b_trt = trt_(ctx.network, input_a, input_b)
     output = ctx.method_return
+    input_a_trt, input_b_trt = add_missing_trt_tensors(ctx.network, [input_a, input_b])
+    input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], output.ndim - 1)
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, trt.ElementWiseOperation.DIV)
     output._trt = layer.get_output(0)
     
@@ -91,3 +93,31 @@ class RDivFloat(torch.nn.Module):
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3, 3)])
 def test_rdiv_float():
     return RDivFloat()
+
+
+class DivConstantNoBatch(torch.nn.Module):
+    def __init__(self):
+        super(DivConstantNoBatch, self).__init__()
+        self.register_buffer('y', torch.ones((3, 10, 10)))
+
+    def forward(self, x):
+        return x / self.y
+
+    
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 10, 10)])
+def test_div_constant_nobatch():
+    return DivConstantNoBatch()
+
+
+class DivConstantBatch(torch.nn.Module):
+    def __init__(self):
+        super(DivConstantBatch, self).__init__()
+        self.register_buffer('y', torch.ones((1, 3, 10, 10)))
+
+    def forward(self, x):
+        return x / self.y
+
+    
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 10, 10)])
+def test_div_constant_batch():
+    return DivConstantBatch()

--- a/torch2trt/converters/identity.py
+++ b/torch2trt/converters/identity.py
@@ -7,6 +7,6 @@ from torch2trt.torch2trt import *
 @tensorrt_converter('torch.nn.functional.dropout3d')
 def convert_identity(ctx):
     input = ctx.method_args[0]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     output._trt = input_trt

--- a/torch2trt/converters/interpolate.py
+++ b/torch2trt/converters/interpolate.py
@@ -24,7 +24,7 @@ def get_interpolate_plugin(size, mode, align_corners):
 @tensorrt_converter('torch.nn.functional.interpolate', enabled=trt_version() < '7.1' and has_interpolate_plugin())
 def convert_interpolate_plugin(ctx):
     input = ctx.method_args[0]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
 
     try:
@@ -60,7 +60,7 @@ def convert_interpolate_trt7(ctx):
 
     input_dim = input.dim() - 2
     
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     layer = ctx.network.add_resize(input=input_trt)
 

--- a/torch2trt/converters/max.py
+++ b/torch2trt/converters/max.py
@@ -6,8 +6,9 @@ from .unary import UnaryModule
 def __convert_max_elementwise(ctx):
     input_a = ctx.method_args[0]
     input_b = ctx.method_args[1]
-    input_a_trt, input_b_trt = trt_(ctx.network, input_a, input_b)
     output = ctx.method_return
+    input_a_trt, input_b_trt = add_missing_trt_tensors(ctx.network, [input_a, input_b])
+    input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], output.ndim - 1)
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, trt.ElementWiseOperation.MAX)
     output._trt = layer.get_output(0)
     
@@ -16,7 +17,7 @@ def __convert_max_reduce(ctx):
     input = ctx.method_args[0]
     dim = get_arg(ctx, 'dim', pos=1, default=tuple(range(1, input.ndim)))
     keepdim = get_arg(ctx, 'keepdim', pos=2, default=False)
-    input_trt= trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output_val = ctx.method_return[0]
     output_idx = ctx.method_return[1]
     layer = ctx.network.add_reduce(input_trt,  trt.ReduceOperation.MAX, torch_dim_to_trt_axes(dim), keepdim)

--- a/torch2trt/converters/max_pool2d.py
+++ b/torch2trt/converters/max_pool2d.py
@@ -13,7 +13,7 @@ def convert_max_pool2d(ctx):
     ceil_mode = get_arg(ctx, 'ceil_mode', pos=5, default=False)
     
     # get input trt tensor (or create constant if it doesn't exist)
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     
     output = ctx.method_return
 

--- a/torch2trt/converters/mean.py
+++ b/torch2trt/converters/mean.py
@@ -6,7 +6,7 @@ from torch2trt.module_test import add_module_test
 @tensorrt_converter('torch.Tensor.mean')
 def convert_mean(ctx):
     input = ctx.method_args[0]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     
     # get dims from args or kwargs

--- a/torch2trt/converters/min.py
+++ b/torch2trt/converters/min.py
@@ -6,8 +6,9 @@ from .unary import UnaryModule
 def __convert_min_elementwise(ctx):
     input_a = ctx.method_args[0]
     input_b = ctx.method_args[1]
-    input_a_trt, input_b_trt = trt_(ctx.network, input_a, input_b)
     output = ctx.method_return
+    input_a_trt, input_b_trt = add_missing_trt_tensors(ctx.network, [input_a, input_b])
+    input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], output.ndim - 1)
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, trt.ElementWiseOperation.MIN)
     output._trt = layer.get_output(0)
     
@@ -16,7 +17,7 @@ def __convert_min_reduce(ctx):
     input = ctx.method_args[0]
     dim = get_arg(ctx, 'dim', pos=1, default=tuple(range(1,input.ndim)))
     keepdim = get_arg(ctx, 'keepdim', pos=2, default=False)
-    input_trt= trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output_val = ctx.method_return[0]
     output_idx = ctx.method_return[1]
     layer = ctx.network.add_reduce(input_trt,  trt.ReduceOperation.MIN, torch_dim_to_trt_axes(dim), keepdim)

--- a/torch2trt/converters/mul.py
+++ b/torch2trt/converters/mul.py
@@ -9,8 +9,9 @@ from torch2trt.module_test import add_module_test
 def convert_mul(ctx):
     input_a = ctx.method_args[0]
     input_b = ctx.method_args[1]
-    input_a_trt, input_b_trt = trt_(ctx.network, input_a, input_b)
     output = ctx.method_return
+    input_a_trt, input_b_trt = add_missing_trt_tensors(ctx.network, [input_a, input_b])
+    input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], output.ndim - 1)
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, trt.ElementWiseOperation.PROD)
     output._trt = layer.get_output(0)
 
@@ -77,3 +78,31 @@ class RMulFloat(torch.nn.Module):
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3, 3)])
 def test_rmul_float():
     return RMulFloat()
+
+
+class MulConstantNoBatch(torch.nn.Module):
+    def __init__(self):
+        super(MulConstantNoBatch, self).__init__()
+        self.register_buffer('y', torch.ones((3, 10, 10)))
+
+    def forward(self, x):
+        return x * self.y
+
+    
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 10, 10)])
+def test_mul_constant_nobatch():
+    return MulConstantNoBatch()
+
+
+class MulConstantBatch(torch.nn.Module):
+    def __init__(self):
+        super(MulConstantBatch, self).__init__()
+        self.register_buffer('y', torch.ones((1, 3, 10, 10)))
+
+    def forward(self, x):
+        return x * self.y
+
+    
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 10, 10)])
+def test_mul_constant_batch():
+    return MulConstantBatch()

--- a/torch2trt/converters/normalize.py
+++ b/torch2trt/converters/normalize.py
@@ -14,7 +14,8 @@ def convert_normalize(ctx):
     output = ctx.method_return
     
     # add broadcastable scalar constants to network
-    input_trt, eps_trt, p_trt, p_inv_trt = trt_(ctx.network, input, eps, p, 1.0 / p)
+    input_trt, eps_trt, p_trt, p_inv_trt = add_missing_trt_tensors(ctx.network, [input, eps, p, 1.0 / p])
+    input_trt, eps_trt, p_trt, p_inv_trt = broadcast_trt_tensors(ctx.network, [input_trt, eps_trt, p_trt, p_inv_trt], len(input_trt.shape))
     
     # compute norm = sum(abs(x)**p, dim=dim)**(1./p)
     norm = ctx.network.add_unary(input_trt, trt.UnaryOperation.ABS).get_output(0)

--- a/torch2trt/converters/pad.py
+++ b/torch2trt/converters/pad.py
@@ -5,7 +5,7 @@ from torch2trt.module_test import add_module_test
 @tensorrt_converter('torch.nn.functional.pad')
 def convert_pad(ctx):
     input = ctx.method_args[0]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     
     pad = ctx.method_args[1]

--- a/torch2trt/converters/permute.py
+++ b/torch2trt/converters/permute.py
@@ -5,7 +5,7 @@ from torch2trt.module_test import add_module_test
 @tensorrt_converter('torch.Tensor.permute')
 def convert_permute(ctx):
     input = ctx.method_args[0]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     
     # permutation -1 because TRT does not include batch dim

--- a/torch2trt/converters/pow.py
+++ b/torch2trt/converters/pow.py
@@ -8,8 +8,9 @@ from torch2trt.module_test import add_module_test
 def convert_pow(ctx):
     input_a = ctx.method_args[0]
     input_b = ctx.method_args[1]
-    input_a_trt, input_b_trt = trt_(ctx.network, input_a, input_b)
     output = ctx.method_return
+    input_a_trt, input_b_trt = add_missing_trt_tensors(ctx.network, [input_a, input_b])
+    input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], output.ndim - 1)
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, trt.ElementWiseOperation.POW)
     output._trt = layer.get_output(0)
 
@@ -18,8 +19,9 @@ def convert_pow(ctx):
 def convert_pow(ctx):
     input_a = ctx.method_args[1]
     input_b = ctx.method_args[0]  # flipped for rpow
-    input_a_trt, input_b_trt = trt_(ctx.network, input_a, input_b)
     output = ctx.method_return
+    input_a_trt, input_b_trt = add_missing_trt_tensors(ctx.network, [input_a, input_b])
+    input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], output.ndim - 1)
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, trt.ElementWiseOperation.POW)
     output._trt = layer.get_output(0)
     

--- a/torch2trt/converters/prelu.py
+++ b/torch2trt/converters/prelu.py
@@ -11,7 +11,7 @@ def convert_prelu(ctx):
     weight_shape = [1] * (len(input.shape) - 1)
     weight_shape[0] = weight.numel()
     
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     
    
     # y = prelu(x) = relu(x) - alpha * relu(-x)

--- a/torch2trt/converters/prod.py
+++ b/torch2trt/converters/prod.py
@@ -9,7 +9,7 @@ def convert_prod(ctx):
     input = ctx.method_args[0]
     dim = get_arg(ctx, 'dim', pos=1, default=tuple(range(1, input.ndim)))
     keepdim = get_arg(ctx, 'keepdim', pos=2, default=False)
-    input_trt= trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     layer = ctx.network.add_reduce(input_trt,  trt.ReduceOperation.PROD, torch_dim_to_trt_axes(dim), keepdim)
     output._trt = layer.get_output(0)

--- a/torch2trt/converters/sigmoid.py
+++ b/torch2trt/converters/sigmoid.py
@@ -6,7 +6,7 @@ from torch2trt.module_test import add_module_test
 @tensorrt_converter('torch.sigmoid')
 def convert_sigmoid(ctx):
     input = ctx.method_args[0]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     
     layer = ctx.network.add_activation(input_trt, trt.ActivationType.SIGMOID)

--- a/torch2trt/converters/softmax.py
+++ b/torch2trt/converters/softmax.py
@@ -5,7 +5,7 @@ from torch2trt.module_test import add_module_test
 @tensorrt_converter('torch.nn.functional.softmax')
 def convert_softmax(ctx):
     input = ctx.method_args[0]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
 
     # get dims from args or kwargs

--- a/torch2trt/converters/split.py
+++ b/torch2trt/converters/split.py
@@ -6,7 +6,7 @@ from torch2trt.module_test import add_module_test
 @tensorrt_converter('torch.Tensor.split')
 def convert_split(ctx):
     input = get_arg(ctx, 'input', 0, None)
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     # we don't need to parse split/chunk (arg 1)
     # since we infer size from output tensors
     dim = get_arg(ctx, 'dim', 2, 0)

--- a/torch2trt/converters/sub.py
+++ b/torch2trt/converters/sub.py
@@ -8,8 +8,9 @@ from torch2trt.module_test import add_module_test
 def convert_sub(ctx):
     input_a = ctx.method_args[0]
     input_b = ctx.method_args[1]
-    input_a_trt, input_b_trt = trt_(ctx.network, input_a, input_b)
     output = ctx.method_return
+    input_a_trt, input_b_trt = add_missing_trt_tensors(ctx.network, [input_a, input_b])
+    input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], output.ndim - 1)
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, trt.ElementWiseOperation.SUB)
     output._trt = layer.get_output(0)
 
@@ -18,8 +19,9 @@ def convert_sub(ctx):
 def convert_sub(ctx):
     input_a = ctx.method_args[1]
     input_b = ctx.method_args[0]  # flipped for rsub
-    input_a_trt, input_b_trt = trt_(ctx.network, input_a, input_b)
     output = ctx.method_return
+    input_a_trt, input_b_trt = add_missing_trt_tensors(ctx.network, [input_a, input_b])
+    input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], output.ndim - 1)
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, trt.ElementWiseOperation.SUB)
     output._trt = layer.get_output(0)
     
@@ -87,3 +89,30 @@ class RSubFloat(torch.nn.Module):
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 224, 224)])
 def test_rsub_float():
     return RSubFloat()
+
+class SubConstantNoBatch(torch.nn.Module):
+    def __init__(self):
+        super(SubConstantNoBatch, self).__init__()
+        self.register_buffer('y', torch.ones((3, 10, 10)))
+
+    def forward(self, x):
+        return x - self.y
+
+    
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 10, 10)])
+def test_sub_constant_nobatch():
+    return SubConstantNoBatch()
+
+
+class SubConstantBatch(torch.nn.Module):
+    def __init__(self):
+        super(SubConstantBatch, self).__init__()
+        self.register_buffer('y', torch.ones((1, 3, 10, 10)))
+
+    def forward(self, x):
+        return x - self.y
+
+    
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 10, 10)])
+def test_sub_constant_batch():
+    return SubConstantBatch()

--- a/torch2trt/converters/sum.py
+++ b/torch2trt/converters/sum.py
@@ -9,7 +9,7 @@ def convert_sum(ctx):
     input = ctx.method_args[0]
     dim = get_arg(ctx, 'dim', pos=1, default=tuple(range(1, input.ndim)))
     keepdim = get_arg(ctx, 'keepdim', pos=2, default=False)
-    input_trt= trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     layer = ctx.network.add_reduce(input_trt,  trt.ReduceOperation.SUM, torch_dim_to_trt_axes(dim), keepdim)
     output._trt = layer.get_output(0)
@@ -44,7 +44,7 @@ class DisparityRegression(nn.Module):
         self.register_buffer('disp', torch.arange(maxdisp, dtype=torch.float32).view(maxdisp, 1, 1))
 
     def forward(self, x):      
-        return torch.sum(x * self.disp, 1) 
+        return x * self.disp#, 1) 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 10, 3, 3)])
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 10, 23, 23)])

--- a/torch2trt/converters/tanh.py
+++ b/torch2trt/converters/tanh.py
@@ -6,7 +6,7 @@ from torch2trt.module_test import add_module_test
 @tensorrt_converter('torch.tanh')
 def convert_tanh(ctx):
     input = ctx.method_args[0]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     
     layer = ctx.network.add_activation(input_trt, trt.ActivationType.TANH)

--- a/torch2trt/converters/transpose.py
+++ b/torch2trt/converters/transpose.py
@@ -5,7 +5,7 @@ from torch2trt.module_test import add_module_test
 @tensorrt_converter("torch.transpose", enabled=trt_version() < '7.0')
 def convert_transpose(ctx):
     input = ctx.method_args[0]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     # permutation -1 because TRT does not include batch dim
     permutation = list(range(len(input.shape) - 1))
@@ -21,7 +21,7 @@ def convert_transpose(ctx):
 @tensorrt_converter('torch.transpose', enabled=trt_version() >= '7.0')
 def convert_transpose_trt7(ctx):
     input = ctx.method_args[0]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     # permutation -1 because TRT does not include batch dim
     permutation = list(range(len(input.shape) - 1))

--- a/torch2trt/converters/unary.py
+++ b/torch2trt/converters/unary.py
@@ -4,7 +4,7 @@ from torch2trt.module_test import add_module_test
         
 def __convert_unary(ctx, op):
     input = get_arg(ctx, 'input', pos=0, default=None)
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     layer = ctx.network.add_unary(input_trt, op)
     output._trt = layer.get_output(0)

--- a/torch2trt/converters/view.py
+++ b/torch2trt/converters/view.py
@@ -11,7 +11,7 @@ from torch2trt.module_test import add_module_test
 @tensorrt_converter('torch.unsqueeze')
 def convert_view(ctx):
     input = ctx.method_args[0]
-    input_trt = trt_(ctx.network, input)
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     output = ctx.method_return
     layer = ctx.network.add_shuffle(input_trt)
     layer.reshape_dims = tuple(output.shape[1:])

--- a/torch2trt/test.py
+++ b/torch2trt/test.py
@@ -4,6 +4,7 @@ import time
 import argparse
 import re
 import runpy
+import traceback
 from termcolor import colored
 
 
@@ -134,6 +135,8 @@ if __name__ == '__main__':
             line = '| %s | %s | %s | %s | N/A | N/A | N/A | N/A | N/A |' % (name, test.dtype.__repr__().split('.')[-1], str(test.input_shapes), str(test.torch2trt_kwargs))
             print(colored(line, 'red'))
             num_error += 1
+            tb = traceback.format_exc()
+            print(tb)
             
         with open(args.output, 'a+') as f:
             f.write(line + '\n')

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -114,7 +114,70 @@ def check_torch_dtype(*tensors):
     )  # , 'Data type could not be inferred from any item in list')
     return dtype
 
+    
+def add_missing_trt_tensors(network, tensors):
+    """Creates missing TensorRT tensors as constants and attaches them to the Torch Tensors"""
+    trt_tensors = [None] * len(tensors)
 
+    dtype = check_torch_dtype(*tensors)
+
+    for i, t in enumerate(tensors):
+        trt_tensor = None
+
+        # GET TRT TENSOR (OR CREATE TRT CONSTANT)
+
+        # get tensor w/ _trt
+        if isinstance(t, torch.Tensor) and hasattr(t, "_trt"):
+            trt_tensor = t._trt
+
+        # or... add constant for leaf tensor w/o _trt
+        elif isinstance(t, torch.Tensor) and not hasattr(t, "_trt"):
+            
+            # remove all preceding ones, these can be re-inserted later when broadcasting
+            num_preceding_ones = 0
+            for i in range(t.ndim):
+                if int(t.shape[i]) == 1:
+                    num_preceding_ones += 1
+            shape = tuple(t.shape[num_preceding_ones:])
+            
+            weight = t.detach().cpu().numpy()
+            t._trt = network.add_constant(shape, weight).get_output(0)
+            trt_tensor = t._trt
+
+        # or... add constant for scalar primitive
+        elif isinstance(t, float) or isinstance(t, int):
+            shape = (1,)
+            scalar = t * torch.ones(shape, dtype=dtype).cpu().numpy()
+            trt_tensor = network.add_constant(shape, scalar).get_output(0)
+
+        assert trt_tensor is not None
+
+        trt_tensors[i] = trt_tensor
+
+    return trt_tensors
+    
+
+def broadcast_trt_tensors(network, trt_tensors, broadcast_ndim):
+    """Broadcast TensorRT tensors to the specified dimension by pre-padding shape 1 dims"""
+    broadcasted_trt_tensors = [None] * len(tensors)
+    
+    for i, t in enumerate(trt_tensors):
+        
+        if len(trt_tensor.shape) < broadcast_ndim:
+            # append 1 size dims to front
+            diff = broadcast_ndim - len(trt_tensor.shape)
+            shape = tuple([1] * diff + list(trt_tensor.shape))
+            layer = network.add_shuffle(trt_tensor)
+            layer.reshape_dims = shape
+            trt_tensor = layer.get_output(0)
+        else:
+            trt_tensor = t
+
+        broadcasted_trt_tensors[i] = trt_tensor
+        
+    return broadcast_trt_tensors
+    
+    
 def trt_(network, *tensors):
     """Creates missing TensorRT tensors and adds shuffle layers to make tensors broadcastable"""
     trt_tensors = [None] * len(tensors)

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -135,8 +135,8 @@ def add_missing_trt_tensors(network, tensors):
             
             # remove all preceding ones, these can be re-inserted later when broadcasting
             num_preceding_ones = 0
-            for i in range(t.ndim):
-                if int(t.shape[i]) == 1:
+            for j in range(t.ndim):
+                if int(t.shape[j]) == 1:
                     num_preceding_ones += 1
             shape = tuple(t.shape[num_preceding_ones:])
             

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -159,15 +159,15 @@ def add_missing_trt_tensors(network, tensors):
 
 def broadcast_trt_tensors(network, trt_tensors, broadcast_ndim):
     """Broadcast TensorRT tensors to the specified dimension by pre-padding shape 1 dims"""
-    broadcasted_trt_tensors = [None] * len(tensors)
+    broadcasted_trt_tensors = [None] * len(trt_tensors)
     
     for i, t in enumerate(trt_tensors):
         
-        if len(trt_tensor.shape) < broadcast_ndim:
+        if len(t.shape) < broadcast_ndim:
             # append 1 size dims to front
-            diff = broadcast_ndim - len(trt_tensor.shape)
-            shape = tuple([1] * diff + list(trt_tensor.shape))
-            layer = network.add_shuffle(trt_tensor)
+            diff = broadcast_ndim - len(t.shape)
+            shape = tuple([1] * diff + list(t.shape))
+            layer = network.add_shuffle(t)
             layer.reshape_dims = shape
             trt_tensor = layer.get_output(0)
         else:
@@ -175,7 +175,7 @@ def broadcast_trt_tensors(network, trt_tensors, broadcast_ndim):
 
         broadcasted_trt_tensors[i] = trt_tensor
         
-    return broadcast_trt_tensors
+    return broadcasted_trt_tensors
     
     
 def trt_(network, *tensors):


### PR DESCRIPTION
- adds ``add_missing_trt_tensors`` to add constants for torch tensors missing TRT counterparts.  This method will use the minimum number of dimensions possible by removing preceding dimensions of size 1.  This allows for later broadcasting
- adds ``broadcast_trt_tensors`` to allow for explicit broadcasting of TensorRT tensors.
- deprecates ``trt_`` method, which is known to produce invalid broadcasting for constants with batch dimensions