### PR TITLE
Assert that inputs are contiguous

### DIFF
--- a/torch2trt/tests/test_contiguous.py
+++ b/torch2trt/tests/test_contiguous.py
@@ -1,0 +1,20 @@
+import torch
+from torch2trt import torch2trt
+
+
+def test_contiguous():
+    net = torch.nn.Conv2d(3, 10, kernel_size=3)
+    net.eval().cuda()
+
+    test_tensor = torch.randn((1, 25, 25, 3)).cuda().permute((0, 3, 1, 2))
+
+    with torch.no_grad():
+	test_out = net(test_tensor)
+
+    with torch.no_grad():
+	trt_net = torch2trt(net, [test_tensor])
+	test_trt_out = trt_net(test_tensor)
+
+    delta = (test_out.contiguous() - test_trt_out.contiguous()).abs().sum()
+    assert delta < 1e-3, f"Delta: {delta}"
+

--- a/torch2trt/tests/test_contiguous.py
+++ b/torch2trt/tests/test_contiguous.py
@@ -9,11 +9,11 @@ def test_contiguous():
     test_tensor = torch.randn((1, 25, 25, 3)).cuda().permute((0, 3, 1, 2))
 
     with torch.no_grad():
-	test_out = net(test_tensor)
+        test_out = net(test_tensor)
 
     with torch.no_grad():
-	trt_net = torch2trt(net, [test_tensor])
-	test_trt_out = trt_net(test_tensor)
+        trt_net = torch2trt(net, [test_tensor])
+        test_trt_out = trt_net(test_tensor)
 
     delta = (test_out.contiguous() - test_trt_out.contiguous()).abs().sum()
     assert delta < 1e-3, f"Delta: {delta}"

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -426,10 +426,8 @@ class TRTModule(torch.nn.Module):
             bindings[idx] = output.data_ptr()
 
         for i, input_name in enumerate(self.input_names):
-            if not inputs[i].is_contiguous():
-                raise ValueError("Input %s is not contiguous" % input_name)
             idx = self.engine.get_binding_index(input_name)
-            bindings[idx] = inputs[i].data_ptr()
+            bindings[idx] = inputs[i].contiguous().data_ptr()
 
         self.context.execute_async(
             batch_size, bindings, torch.cuda.current_stream().cuda_stream

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -426,6 +426,8 @@ class TRTModule(torch.nn.Module):
             bindings[idx] = output.data_ptr()
 
         for i, input_name in enumerate(self.input_names):
+            if not inputs[i].is_contiguous():
+                raise ValueError("Input %s is not contiguous" % input_name)
             idx = self.engine.get_binding_index(input_name)
             bindings[idx] = inputs[i].data_ptr()
 


### PR DESCRIPTION
@jaybdub, I've spent last 24 hours figuring out why PyTorch and TensorRT predictions differed, and it ended up being caused by strided tensor that was not accounted for.  With this change I'd like to ensure this doesn't happen again.

Can you suggest where should I add tests for it?