### PR TITLE
FP16 fallback support for INT8 calibration

### DIFF
--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -517,6 +517,7 @@ def torch2trt(module,
             int8_calib_dataset = TensorBatchDataset(inputs_in)
 
         builder.int8_mode = True
+        builder.fp16_mode = True
 
         # @TODO(jwelsh):  Should we set batch_size=max_batch_size?  Need to investigate memory consumption
         builder.int8_calibrator = DatasetCalibrator(


### PR DESCRIPTION
Hi John

Currently when TRT does Post Training Calibration, it falls back to FP32 for the layers that could not be converted to INT8. However, making `builder.fp16_mode=True` , we can force the builder to fallback to FP16 instead of FP32. 

I have profiled the INT8 engine after calibration and it invokes both FP16 and INT8 kernels so I can safely say it's working. 

Thanks
Kshitij 