### PR TITLE
New Converter and Plugin for GroupNorm - Enables fallback to pytorch torch.nn.group_norm

### DIFF
--- a/build.py
+++ b/build.py
@@ -5,6 +5,7 @@ from string import Template
 
 PLUGINS = [
     'interpolate',
+    'group_norm',
 ]
 
 BASE_FOLDER = 'torch2trt/converters'

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,10 @@ def trt_lib_dir():
 
 ext_modules = []
 
-plugins_ext_module = [
-    CUDAExtension(
-        name='interpolate_plugin', 
+plugins_ext_module = CUDAExtension(
+        name='plugins', 
         sources=[
-            'torch2trt/plugins/interpolate.cpp'
+            'torch2trt/plugins/plugins.cpp'
         ],
         include_dirs=[
             trt_inc_dir()
@@ -30,30 +29,9 @@ plugins_ext_module = [
             'cxx': ['-DUSE_DEPRECATED_INTLIST'] if torch.__version__ < "1.5" else [],
             'nvcc': []
         }
-    ),
-    CUDAExtension(
-        name='group_norm_plugin', 
-        sources=[
-            'torch2trt/plugins/group_norm.cpp'
-            ],
-        include_dirs=[
-            trt_inc_dir()
-            ],
-        library_dirs=[
-            trt_lib_dir()
-            ],
-        libraries=[
-            'nvinfer'
-            ],
-        extra_compile_args={
-            'cxx': ['-DUSE_DEPRECATED_INTLIST'] if torch.__version__ < "1.5" else [],
-            'nvcc': []
-            }
-        ),
-]
-
+    )
 if '--plugins' in sys.argv:
-    ext_modules.extend(plugins_ext_module)
+    ext_modules.append(plugins_ext_module)
     sys.argv.remove('--plugins')
     
 

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,9 @@ def trt_lib_dir():
 
 ext_modules = []
 
-plugins_ext_module = CUDAExtension(
-        name='plugins', 
+plugins_ext_module = [
+    CUDAExtension(
+        name='interpolate_plugin', 
         sources=[
             'torch2trt/plugins/interpolate.cpp'
         ],
@@ -29,10 +30,30 @@ plugins_ext_module = CUDAExtension(
             'cxx': ['-DUSE_DEPRECATED_INTLIST'] if torch.__version__ < "1.5" else [],
             'nvcc': []
         }
-)
+    ),
+    CUDAExtension(
+        name='group_norm_plugin', 
+        sources=[
+            'torch2trt/plugins/group_norm.cpp'
+            ],
+        include_dirs=[
+            trt_inc_dir()
+            ],
+        library_dirs=[
+            trt_lib_dir()
+            ],
+        libraries=[
+            'nvinfer'
+            ],
+        extra_compile_args={
+            'cxx': ['-DUSE_DEPRECATED_INTLIST'] if torch.__version__ < "1.5" else [],
+            'nvcc': []
+            }
+        ),
+]
 
 if '--plugins' in sys.argv:
-    ext_modules.append(plugins_ext_module)
+    ext_modules.extend(plugins_ext_module)
     sys.argv.remove('--plugins')
     
 

--- a/torch2trt/converters/__init__.py
+++ b/torch2trt/converters/__init__.py
@@ -32,6 +32,7 @@ from .getitem import *
 from .identity import *
 from .instance_norm import *
 from .interpolate import *
+from .group_norm import *
 from .max import *
 from .max_pool2d import *
 from .mean import *

--- a/torch2trt/converters/group_norm.py
+++ b/torch2trt/converters/group_norm.py
@@ -39,7 +39,7 @@ def test_group_norm_trt_g2_fp32():
     return torch.nn.GroupNorm(2, 10)
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 10, 112, 112)], has_group_norm_plugin())
-def test_group_norm_trt_g2_fp16():
+def test_group_norm_trt_g2_eps_fp32():
     return torch.nn.GroupNorm(2, 10, eps=1e-4)
 
 

--- a/torch2trt/converters/group_norm.py
+++ b/torch2trt/converters/group_norm.py
@@ -5,16 +5,15 @@ import collections
 
 def has_group_norm_plugin():
     try:
-        #from torch2trt.plugins import GroupNormPlugin
-        from torch2trt.group_norm_plugin import GroupNormPlugin
+        from torch2trt.plugins import GroupNormPlugin
         return True
     except:
         return False
 
 
 def get_group_norm_plugin(num_groups): #, num_channels, height_width, eps):
-    #from torch2trt.plugins import GroupNormPlugin
-    from torch2trt.group_norm_plugin import GroupNormPlugin
+    from torch2trt.plugins import GroupNormPlugin
+    #from torch2trt.group_norm_plugin import GroupNormPlugin
     PLUGIN_NAME = 'group_norm'
     registry = trt.get_plugin_registry()
     creator = [c for c in registry.plugin_creator_list if c.name == PLUGIN_NAME and c.plugin_namespace == 'torch2trt'][0]

--- a/torch2trt/converters/group_norm.py
+++ b/torch2trt/converters/group_norm.py
@@ -1,7 +1,6 @@
 import torch.nn as nn
 from torch2trt.torch2trt import *                                 
 from torch2trt.module_test import add_module_test
-import collections
 
 def has_group_norm_plugin():
     try:
@@ -11,27 +10,23 @@ def has_group_norm_plugin():
         return False
 
 
-def get_group_norm_plugin(num_groups): #, num_channels, height_width, eps):
+def get_group_norm_plugin(num_groups, eps):
     from torch2trt.plugins import GroupNormPlugin
-    #from torch2trt.group_norm_plugin import GroupNormPlugin
     PLUGIN_NAME = 'group_norm'
     registry = trt.get_plugin_registry()
     creator = [c for c in registry.plugin_creator_list if c.name == PLUGIN_NAME and c.plugin_namespace == 'torch2trt'][0]
-    torch2trt_plugin = GroupNormPlugin(num_groups=num_groups)
+    torch2trt_plugin = GroupNormPlugin(num_groups=num_groups, eps=eps)
     return creator.deserialize_plugin(PLUGIN_NAME, torch2trt_plugin.serializeToString())
 
-@tensorrt_converter('torch.nn.GroupNorm.forward', enabled=trt_version() >= '7.0' and has_group_norm_plugin())
-def convert_group_norm_trt7(ctx):
+@tensorrt_converter('torch.nn.GroupNorm.forward', has_group_norm_plugin())
+def convert_group_norm_trt(ctx):
     module = ctx.method_args[0]
     input = ctx.method_args[1]
     num_groups = module.num_groups
-    #num_channels = input.shape[1] # NCHW
-    #height = input.shape[2]
-    #width = input.shape[3]
-    #eps = module.eps
+    eps = module.eps
     input_trt = add_missing_trt_tensors(ctx.network, [input])
     output = ctx.method_return
-    plugin = get_group_norm_plugin(num_groups) #, num_channels, height*width, eps)
+    plugin = get_group_norm_plugin(num_groups, eps)
 
     layer = ctx.network.add_plugin_v2(input_trt, plugin)
     
@@ -39,8 +34,13 @@ def convert_group_norm_trt7(ctx):
 
 
 
-@add_module_test(torch.float32, torch.device('cuda'), [(1, 10, 3, 3)], enabled=trt_version() >= '7.0')
-def test_group_norm_trt7():
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 10, 112, 112)], has_group_norm_plugin())
+def test_group_norm_trt_g2_fp32():
     return torch.nn.GroupNorm(2, 10)
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 10, 112, 112)], has_group_norm_plugin())
+def test_group_norm_trt_g2_fp16():
+    return torch.nn.GroupNorm(2, 10, eps=1e-4)
+
 
     

--- a/torch2trt/converters/group_norm.py
+++ b/torch2trt/converters/group_norm.py
@@ -5,14 +5,16 @@ import collections
 
 def has_group_norm_plugin():
     try:
-        from torch2trt.plugins import GroupNormPlugin
+        #from torch2trt.plugins import GroupNormPlugin
+        from torch2trt.group_norm_plugin import GroupNormPlugin
         return True
     except:
         return False
 
 
 def get_group_norm_plugin(num_groups): #, num_channels, height_width, eps):
-    from torch2trt.plugins import GroupNormPlugin
+    #from torch2trt.plugins import GroupNormPlugin
+    from torch2trt.group_norm_plugin import GroupNormPlugin
     PLUGIN_NAME = 'group_norm'
     registry = trt.get_plugin_registry()
     creator = [c for c in registry.plugin_creator_list if c.name == PLUGIN_NAME and c.plugin_namespace == 'torch2trt'][0]

--- a/torch2trt/converters/group_norm.py
+++ b/torch2trt/converters/group_norm.py
@@ -1,0 +1,45 @@
+import torch.nn as nn
+from torch2trt.torch2trt import *                                 
+from torch2trt.module_test import add_module_test
+import collections
+
+def has_group_norm_plugin():
+    try:
+        from torch2trt.plugins import GroupNormPlugin
+        return True
+    except:
+        return False
+
+
+def get_group_norm_plugin(num_groups): #, num_channels, height_width, eps):
+    from torch2trt.plugins import GroupNormPlugin
+    PLUGIN_NAME = 'group_norm'
+    registry = trt.get_plugin_registry()
+    creator = [c for c in registry.plugin_creator_list if c.name == PLUGIN_NAME and c.plugin_namespace == 'torch2trt'][0]
+    torch2trt_plugin = GroupNormPlugin(num_groups=num_groups)
+    return creator.deserialize_plugin(PLUGIN_NAME, torch2trt_plugin.serializeToString())
+
+@tensorrt_converter('torch.nn.GroupNorm.forward', enabled=trt_version() >= '7.0' and has_group_norm_plugin())
+def convert_group_norm_trt7(ctx):
+    module = ctx.method_args[0]
+    input = ctx.method_args[1]
+    num_groups = module.num_groups
+    #num_channels = input.shape[1] # NCHW
+    #height = input.shape[2]
+    #width = input.shape[3]
+    #eps = module.eps
+    input_trt = add_missing_trt_tensors(ctx.network, [input])
+    output = ctx.method_return
+    plugin = get_group_norm_plugin(num_groups) #, num_channels, height*width, eps)
+
+    layer = ctx.network.add_plugin_v2(input_trt, plugin)
+    
+    output._trt = layer.get_output(0)
+
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 10, 3, 3)], enabled=trt_version() >= '7.0')
+def test_group_norm_trt7():
+    return torch.nn.GroupNorm(2, 10)
+
+    

--- a/torch2trt/converters/interpolate.py
+++ b/torch2trt/converters/interpolate.py
@@ -8,14 +8,12 @@ import collections
 def has_interpolate_plugin():
     try:
         from torch2trt.plugins import InterpolatePlugin
-        #from torch2trt.interpolate_plugin import InterpolatePlugin
         return True
     except:
         return False
     
 def get_interpolate_plugin(size, mode, align_corners):
     from torch2trt.plugins import InterpolatePlugin
-    #from torch2trt.interpolate_plugin import InterpolatePlugin
     PLUGIN_NAME = 'interpolate'
     registry = trt.get_plugin_registry()
     creator = [c for c in registry.plugin_creator_list if c.name == PLUGIN_NAME and c.plugin_namespace == 'torch2trt'][0]

--- a/torch2trt/converters/interpolate.py
+++ b/torch2trt/converters/interpolate.py
@@ -7,15 +7,15 @@ import collections
 
 def has_interpolate_plugin():
     try:
-        #from torch2trt.plugins import InterpolatePlugin
-        from torch2trt.interpolate_plugin import InterpolatePlugin
+        from torch2trt.plugins import InterpolatePlugin
+        #from torch2trt.interpolate_plugin import InterpolatePlugin
         return True
     except:
         return False
     
 def get_interpolate_plugin(size, mode, align_corners):
-    #from torch2trt.plugins import InterpolatePlugin
-    from torch2trt.interpolate_plugin import InterpolatePlugin
+    from torch2trt.plugins import InterpolatePlugin
+    #from torch2trt.interpolate_plugin import InterpolatePlugin
     PLUGIN_NAME = 'interpolate'
     registry = trt.get_plugin_registry()
     creator = [c for c in registry.plugin_creator_list if c.name == PLUGIN_NAME and c.plugin_namespace == 'torch2trt'][0]

--- a/torch2trt/converters/interpolate.py
+++ b/torch2trt/converters/interpolate.py
@@ -7,13 +7,15 @@ import collections
 
 def has_interpolate_plugin():
     try:
-        from torch2trt.plugins import InterpolatePlugin
+        #from torch2trt.plugins import InterpolatePlugin
+        from torch2trt.interpolate_plugin import InterpolatePlugin
         return True
     except:
         return False
     
 def get_interpolate_plugin(size, mode, align_corners):
-    from torch2trt.plugins import InterpolatePlugin
+    #from torch2trt.plugins import InterpolatePlugin
+    from torch2trt.interpolate_plugin import InterpolatePlugin
     PLUGIN_NAME = 'interpolate'
     registry = trt.get_plugin_registry()
     creator = [c for c in registry.plugin_creator_list if c.name == PLUGIN_NAME and c.plugin_namespace == 'torch2trt'][0]

--- a/torch2trt/plugins/group_norm.cpp
+++ b/torch2trt/plugins/group_norm.cpp
@@ -220,8 +220,8 @@ public:
     }
     at::Tensor weight_t = at::from_blob(weight.data(), {weight.size()}, [](void*){});
     at::Tensor bias_t = at::from_blob(bias.data(), {bias.size()}, [](void*){});
-    weight_t = weight_t.to(device(c10::kCUDA));
-    bias_t = bias_t.to(device(c10::kCUDA));
+    weight_t = weight_t.to(tensor_options);
+    bias_t = bias_t.to(tensor_options);
 
     // create new torch cuda stream
     at::cuda::CUDAStream torch_stream = at::cuda::getStreamFromPool();
@@ -237,8 +237,7 @@ public:
 
     // enqueue work
     // Group_norm function from PyTorch: https://pytorch.org/cppdocs/api/function_namespaceat_1a6bc1e9504ea440c6c96ff8a8b94333f2.html#exhale-function-namespaceat-1a6bc1e9504ea440c6c96ff8a8b94333f2
-    //at::group_norm(input, num_groups, weight_t, bias_t, eps=eps);
-    at::native_group_norm(input, weight, bias, batchSize, input_sizes[0], input_sizes[1]*input_sizes[2], num_groups, eps);
+    at::group_norm(input, num_groups, weight_t, bias_t, eps=eps);
 
     // capture event on enqueued stream
     cudaEvent_t torch_event;

--- a/torch2trt/plugins/group_norm.cpp
+++ b/torch2trt/plugins/group_norm.cpp
@@ -22,7 +22,9 @@ private:
     DataType dtype;
 
     // configured by user
+    // num_groups for GroupNorm
     int64_t num_groups;
+    // eps for GroupNorm
     double eps;
     
 
@@ -113,7 +115,6 @@ public:
       Dims dims;
       dims.nbDims = inputs->nbDims;
   
-      //dims.d[0] = inputs->d[0];
       for (int i = 0; i < inputs->nbDims; i++) {
         dims.d[i] = inputs->d[i];
       }
@@ -198,7 +199,8 @@ public:
     cudaStreamWaitEvent(torch_stream.stream(), event, 0);
 
     // enqueue work
-    at::group_norm(input, num_groups, {}, {}, eps=eps); // height_width, num_groups, eps);
+    // Group_norm function from PyTorch: https://pytorch.org/cppdocs/api/function_namespaceat_1a6bc1e9504ea440c6c96ff8a8b94333f2.html#exhale-function-namespaceat-1a6bc1e9504ea440c6c96ff8a8b94333f2
+    at::group_norm(input, num_groups, {}, {}, eps=eps);
 
     // capture event on enqueued stream
     cudaEvent_t torch_event;
@@ -226,7 +228,7 @@ public:
   void destroy() override {}
 
   IPluginV2* clone() const override {
-    return new GroupNormPlugin(num_groups, eps); //, num_channels, height_width, eps);
+    return new GroupNormPlugin(num_groups, eps); 
   }
 
   void setPluginNamespace(const char* pluginNamespace) override {}

--- a/torch2trt/plugins/group_norm.cpp
+++ b/torch2trt/plugins/group_norm.cpp
@@ -256,19 +256,6 @@ public:
 
 REGISTER_TENSORRT_PLUGIN(GroupNormPluginCreator);
     
-
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    py::class_<GroupNormPlugin>(m, "GroupNormPlugin")
-	.def(py::init<int64_t>(), py::arg("num_groups"))
-        .def(py::init<const std::string &>(), py::arg("data"))
-        .def("getSerializationSize", &GroupNormPlugin::getSerializationSize)
-        .def("deserializeFromString", &GroupNormPlugin::deserializeFromString)
-        .def("serializeToString", [](const GroupNormPlugin& plugin) {
-            std::string data = plugin.serializeToString();
-            return py::bytes(data);
-        });
-}
-    
 } // namespace torch2trt
 
 

--- a/torch2trt/plugins/group_norm.cpp
+++ b/torch2trt/plugins/group_norm.cpp
@@ -1,0 +1,276 @@
+#include <torch/extension.h>
+#include <torch/script.h>
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <NvInfer.h>
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAEvent.h>
+#include <torch/torch.h>
+#include <cuda_runtime_api.h>
+
+using namespace nvinfer1;
+
+namespace torch2trt {
+
+class GroupNormPlugin : public IPluginV2 {
+private:
+    // configured by class
+    at::TensorOptions tensor_options;
+    std::vector<int64_t> input_sizes;
+    std::vector<int64_t> output_sizes;
+    DataType dtype;
+
+    // configured by user
+    int64_t num_groups;
+    
+
+public:
+
+    // create from arguments
+    GroupNormPlugin(int64_t num_groups) : 
+            num_groups{num_groups}
+    {}
+
+    GroupNormPlugin(const char *data, size_t length) : GroupNormPlugin(std::string(data, length)) {}
+
+    GroupNormPlugin(const std::string &data){
+            deserializeFromString(data);
+    }
+
+    void deserializeFromString(const std::string &data) {
+        std::istringstream data_stream(data);
+        torch::serialize::InputArchive input_archive;
+        input_archive.load_from(data_stream);
+        {
+            torch::IValue value;
+            input_archive.read("num_groups", value);
+#ifdef USE_DEPRECATED_INTLIST
+            num_groups = value.toIntListRef().vec();
+#else
+            num_groups = value.toInt();
+#endif  
+        }
+                {
+            torch::IValue value;
+            input_archive.read("dtype", value);
+            dtype = (DataType) value.toInt();
+        }
+        {
+            torch::IValue value;
+            input_archive.read("input_sizes", value);
+#ifdef USE_DEPRECATED_INTLIST
+            input_sizes = value.toIntListRef().vec();
+#else
+            input_sizes = value.toIntVector();
+#endif  
+        }
+        {
+            torch::IValue value;
+            input_archive.read("output_sizes", value);
+#ifdef USE_DEPRECATED_INTLIST
+            output_sizes = value.toIntListRef().vec();
+#else
+            output_sizes = value.toIntVector();
+#endif  
+        }
+    }
+    std::string serializeToString() const {
+        torch::serialize::OutputArchive output_archive;
+        output_archive.write("num_groups", torch::IValue(num_groups));
+        output_archive.write("dtype", torch::IValue((int) dtype));
+        output_archive.write("input_sizes", torch::IValue(input_sizes));
+        output_archive.write("output_sizes", torch::IValue(output_sizes));
+        std::ostringstream data_str;
+        output_archive.save_to(data_str);
+        return data_str.str();
+    }
+    
+    const char* getPluginType() const override {
+      return "group_norm";
+    };
+
+    const char* getPluginVersion() const override {
+      return "1";
+    }
+
+    int getNbOutputs() const override {
+      return 1;
+    } 
+
+    Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
+      Dims dims;
+      dims.nbDims = inputs->nbDims;
+  
+      //dims.d[0] = inputs->d[0];
+      for (int i = 0; i < inputs->nbDims; i++) {
+        dims.d[i] = inputs->d[i];
+      }
+  
+      return dims;
+    }
+
+    bool supportsFormat(DataType type, PluginFormat format) const override {
+      if (format != PluginFormat::kNCHW) {
+        return false;
+      }
+      if (type == DataType::kINT32 || type == DataType::kINT8) {
+        return false;
+      }
+      return true;
+    }
+
+  void configureWithFormat(const Dims* inputDims, int nbInputs, const Dims* outputDims,
+      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) override {
+    
+    // set data type
+    if (type == DataType::kFLOAT) {
+      tensor_options = tensor_options.dtype(c10::kFloat);
+      dtype = type;
+    } else if (type == DataType::kHALF) {
+      tensor_options = tensor_options.dtype(c10::kHalf);
+      dtype = type;
+    }
+      
+    // set input sizes
+    input_sizes.resize(inputDims[0].nbDims);
+    for (int i = 0; i < inputDims[0].nbDims; i++) {
+      input_sizes[i] = inputDims[0].d[i];
+    }
+
+    // set output sizes
+    output_sizes.resize(outputDims[0].nbDims);
+    for (int i = 0; i < outputDims[0].nbDims; i++) {
+      output_sizes[i] = outputDims[0].d[i];
+    }
+  }
+
+  int initialize() override {
+    // set device
+    tensor_options = tensor_options.device(c10::kCUDA);
+      
+    // set data type
+    if (dtype == DataType::kFLOAT) {
+        tensor_options = tensor_options.dtype(c10::kFloat);
+    } else if (dtype == DataType::kHALF) {
+        tensor_options = tensor_options.dtype(c10::kHalf);
+    }
+      
+    return 0;
+  }
+
+  void terminate() override {}
+
+  size_t getWorkspaceSize(int maxBatchSize) const override { return 0; }
+
+  int enqueue(int batchSize, const void* const* inputs, void** outputs, void* workspace, cudaStream_t stream) override {
+    // get input / output dimensions
+    std::vector<long> batch_input_sizes = input_sizes;
+    std::vector<long> batch_output_sizes = output_sizes;
+    batch_input_sizes.insert(batch_input_sizes.begin(), batchSize);
+    batch_output_sizes.insert(batch_output_sizes.begin(), batchSize);
+
+    // create tensor wrappers
+    at::Tensor input = at::from_blob((void*) inputs[0], batch_input_sizes, [](void*){}, tensor_options);
+    at::Tensor output = at::from_blob(outputs[0], batch_output_sizes, [](void*){}, tensor_options);
+
+    // create new torch cuda stream
+    at::cuda::CUDAStream torch_stream = at::cuda::getStreamFromPool();
+    at::cuda::CUDAStreamGuard torch_guard(torch_stream);
+
+    // capture current work on tensorrt cuda stream
+    cudaEvent_t event;
+    cudaEventCreate(&event);
+    cudaEventRecord(event, stream);
+
+    // make torch cuda stream wait on tensorrt work
+    cudaStreamWaitEvent(torch_stream.stream(), event, 0);
+
+    // enqueue work
+    at::group_norm(input, num_groups); // height_width, num_groups, eps);
+
+    // capture event on enqueued stream
+    cudaEvent_t torch_event;
+    cudaEventCreate(&torch_event);
+    cudaEventRecord(torch_event, torch_stream.stream());
+    cudaStreamWaitEvent(stream, torch_event, 0);
+
+    cudaEventDestroy(event);
+    cudaEventDestroy(torch_event);
+
+    return 0;
+  }
+
+
+  size_t getSerializationSize() const override {
+    return serializeToString().size();
+  }
+    
+  void serialize(void* buffer) const override {
+      std::string data = serializeToString();
+      size_t size = getSerializationSize();
+      data.copy((char *) buffer, size);
+  }
+
+  void destroy() override {}
+
+  IPluginV2* clone() const override {
+    return new GroupNormPlugin(num_groups); //, num_channels, height_width, eps);
+  }
+
+  void setPluginNamespace(const char* pluginNamespace) override {}
+
+  const char *getPluginNamespace() const override {
+    return "torch2trt";
+  }
+
+};
+
+class GroupNormPluginCreator : public IPluginCreator {
+public:
+  GroupNormPluginCreator() {}
+
+  const char *getPluginNamespace() const override {
+    return "torch2trt";
+  }
+
+  const char *getPluginName() const override {
+    return "group_norm";
+  }
+
+  const char *getPluginVersion() const override {
+    return "1";
+  }
+
+  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) override {
+    return new GroupNormPlugin((const char*) data, length);
+  }
+
+  void setPluginNamespace(const char *N) override {}
+  const PluginFieldCollection *getFieldNames() override { return nullptr; }
+
+  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) override { return nullptr; }
+
+};
+
+
+REGISTER_TENSORRT_PLUGIN(GroupNormPluginCreator);
+    
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    py::class_<GroupNormPlugin>(m, "GroupNormPlugin")
+	.def(py::init<int64_t>(), py::arg("num_groups"))
+        .def(py::init<const std::string &>(), py::arg("data"))
+        .def("getSerializationSize", &GroupNormPlugin::getSerializationSize)
+        .def("deserializeFromString", &GroupNormPlugin::deserializeFromString)
+        .def("serializeToString", [](const GroupNormPlugin& plugin) {
+            std::string data = plugin.serializeToString();
+            return py::bytes(data);
+        });
+}
+    
+} // namespace torch2trt
+
+
+
+

--- a/torch2trt/plugins/interpolate.cpp
+++ b/torch2trt/plugins/interpolate.cpp
@@ -281,17 +281,4 @@ public:
 
 REGISTER_TENSORRT_PLUGIN(InterpolatePluginCreator);
     
-
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    py::class_<InterpolatePlugin>(m, "InterpolatePlugin")
-        .def(py::init<std::vector<int64_t>, std::string, bool>(), py::arg("size"), py::arg("mode"), py::arg("align_corners"))
-        .def(py::init<const std::string &>(), py::arg("data"))
-        .def("getSerializationSize", &InterpolatePlugin::getSerializationSize)
-        .def("deserializeFromString", &InterpolatePlugin::deserializeFromString)
-        .def("serializeToString", [](const InterpolatePlugin& plugin) {
-            std::string data = plugin.serializeToString();
-            return py::bytes(data);
-        });
-}
-    
 } // namespace torch2trt

--- a/torch2trt/plugins/plugins.cpp
+++ b/torch2trt/plugins/plugins.cpp
@@ -17,7 +17,7 @@ namespace torch2trt {
                     return py::bytes(data);
                     });
         py::class_<GroupNormPlugin>(m, "GroupNormPlugin")
-            .def(py::init<int64_t>(), py::arg("num_groups"))
+            .def(py::init<int64_t, double>(), py::arg("num_groups"), py::arg("eps"))
             .def(py::init<const std::string &>(), py::arg("data"))
             .def("getSerializationSize", &GroupNormPlugin::getSerializationSize)
             .def("deserializeFromString", &GroupNormPlugin::deserializeFromString)

--- a/torch2trt/plugins/plugins.cpp
+++ b/torch2trt/plugins/plugins.cpp
@@ -1,0 +1,30 @@
+#include <torch/extension.h>
+#include "interpolate.cpp"
+#include "group_norm.cpp"
+
+
+using namespace nvinfer1;
+
+namespace torch2trt {
+    PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+        py::class_<InterpolatePlugin>(m, "InterpolatePlugin")
+            .def(py::init<std::vector<int64_t>, std::string, bool>(), py::arg("size"), py::arg("mode"), py::arg("align_corners"))
+            .def(py::init<const std::string &>(), py::arg("data"))
+            .def("getSerializationSize", &InterpolatePlugin::getSerializationSize)
+            .def("deserializeFromString", &InterpolatePlugin::deserializeFromString)
+            .def("serializeToString", [](const InterpolatePlugin& plugin) {
+                    std::string data = plugin.serializeToString();
+                    return py::bytes(data);
+                    });
+        py::class_<GroupNormPlugin>(m, "GroupNormPlugin")
+            .def(py::init<int64_t>(), py::arg("num_groups"))
+            .def(py::init<const std::string &>(), py::arg("data"))
+            .def("getSerializationSize", &GroupNormPlugin::getSerializationSize)
+            .def("deserializeFromString", &GroupNormPlugin::deserializeFromString)
+            .def("serializeToString", [](const GroupNormPlugin& plugin) {
+                    std::string data = plugin.serializeToString();
+                    return py::bytes(data);
+                    });
+
+    }
+} // namespace torch2trt

--- a/torch2trt/plugins/plugins.cpp
+++ b/torch2trt/plugins/plugins.cpp
@@ -17,7 +17,7 @@ namespace torch2trt {
                     return py::bytes(data);
                     });
         py::class_<GroupNormPlugin>(m, "GroupNormPlugin")
-            .def(py::init<int64_t, double>(), py::arg("num_groups"), py::arg("eps"))
+            .def(py::init<int64_t, std::vector<double>, std::vector<double>, double>(), py::arg("num_groups"), py::arg("weight"), py::arg("bias"), py::arg("eps"))
             .def(py::init<const std::string &>(), py::arg("data"))
             .def("getSerializationSize", &GroupNormPlugin::getSerializationSize)
             .def("deserializeFromString", &GroupNormPlugin::deserializeFromString)


### PR DESCRIPTION
Adding a plugin and converter for `GroupNorm` in Torch2trt. 
Since `GroupNorm` is not implemented in TensorRT yet this will allow a mechanism to fallback to Pytorch when it is called from the model. 

This PR has the following changes:
1. `torch2trt/plugins/group_norm.cpp` 
    - This is the plugin that launches the pytorch `GroupNorm` op - `at::group_norm()`
2. `torch2trt/converters/group_norm.py` 
    - Converter which gets invoked when `torch.nn.group_norm` is used in the users network 
    - This converter will call the plugin to do the computation on the tensor and returns the value.
3. `torch2trt/plugins/plugins.cpp`
    - Refactored the structure of `torch2trt/plugins` 
    - Added a new file `torch2trt/plugins/plugins.cpp`: This is the master file where all the plugins are registered and this will be provided to setup.py to build all the plugins.


**Environment Settings:** 
(Tested on 20.03 and 20.06 NGC containers)
PyTorch Versions: 1.5 and 1.6 
TensorRT Versions: 7.0 and 7.1
Platform: TitanRTX

**Attaching the results of:**
`python3 -m torch2trt.test --name=converters --tolerance=1e-2`
[group_norm_test.txt](https://github.com/NVIDIA-AI-IOT/torch2trt/files/5442200/group_norm_test.txt)

**To run only the group_norm converter:**
`python -m torch2trt.test --name=group_norm`

@jaybdub 



 