### PR TITLE
[DO NOT MERGE] Qat mapping experiment TRT7

### DIFF
--- a/examples/quantization_aware_training/infer.py
+++ b/examples/quantization_aware_training/infer.py
@@ -4,6 +4,7 @@ import numpy as np
 import argparse
 import os,sys 
 from resnet import resnet18
+from mobilenetv2 import MobileNetV2 
 from parser import parse_args
 from torch2trt import torch2trt
 import tensorrt as trt
@@ -20,26 +21,21 @@ def main():
     
 
     if args.m == "resnet18":
-        if args.netqat:
-            model=resnet18(qat_mode=True,infer=True)
-        else:
             model=resnet18()
+    elif args.m == "mobilenet":
+            model = MobileNetV2()
     else:
         raise NotImplementedError("{} model not found".format(args.m))
-
 
     model = model.cuda().eval()
 
     print(model)
-    for k,v in model.state_dict().items():
-        if 'learned_amax' in k:
-            print(v)
 
     rand_in = torch.randn([1,3,32,32],dtype=torch.float32).cuda()
     
     #Converting the model to TRT
 
-    trt_model = torch2trt(model,[rand_in],log_level=trt.Logger.INFO,fp16_mode=True,int8_mode=True,max_batch_size=1,qat_mode=True,strict_type_constraints=True)
+    trt_model = torch2trt(model,[rand_in],log_level=trt.Logger.INFO,fp16_mode=True,int8_mode=True,max_batch_size=1,hack_dynamic_range=args.hack_dynamic_range,qat_mode=True,strict_type_constraints=True)
 
 if __name__ == "__main__":
     main()

--- a/examples/quantization_aware_training/infer.py
+++ b/examples/quantization_aware_training/infer.py
@@ -3,8 +3,8 @@ import torch.nn as nn
 import numpy as np 
 import argparse
 import os,sys 
-from .resnet import resnet18
-from .parser import parse_args
+from resnet import resnet18
+from parser import parse_args
 from torch2trt import torch2trt
 import tensorrt as trt
 

--- a/examples/quantization_aware_training/infer.py
+++ b/examples/quantization_aware_training/infer.py
@@ -1,0 +1,46 @@
+import torch 
+import torch.nn as nn
+import numpy as np 
+import argparse
+import os,sys 
+from .resnet import resnet18
+from .parser import parse_args
+from torch2trt import torch2trt
+import tensorrt as trt
+
+def main():
+    args = parse_args()
+
+    args.cuda = not args.no_cuda and torch.cuda.is_available()
+    torch.manual_seed(78543)
+
+    if args.cuda:
+        torch.backends.cudnn.benchmark = True
+        torch.cuda.manual_seed(args.seed)
+    
+
+    if args.m == "resnet18":
+        if args.netqat:
+            model=resnet18(qat_mode=True,infer=True)
+        else:
+            model=resnet18()
+    else:
+        raise NotImplementedError("{} model not found".format(args.m))
+
+
+    model = model.cuda().eval()
+
+    print(model)
+    for k,v in model.state_dict().items():
+        if 'learned_amax' in k:
+            print(v)
+
+    rand_in = torch.randn([1,3,32,32],dtype=torch.float32).cuda()
+    
+    #Converting the model to TRT
+
+    trt_model = torch2trt(model,[rand_in],log_level=trt.Logger.INFO,fp16_mode=True,int8_mode=True,max_batch_size=1,qat_mode=True,strict_type_constraints=True)
+
+if __name__ == "__main__":
+    main()
+

--- a/examples/quantization_aware_training/mobilenetv2.py
+++ b/examples/quantization_aware_training/mobilenetv2.py
@@ -1,0 +1,160 @@
+from torch import nn
+#from .utils import load_state_dict_from_url
+
+
+__all__ = ['MobileNetV2', 'mobilenet_v2']
+
+
+model_urls = {
+    'mobilenet_v2': 'https://download.pytorch.org/models/mobilenet_v2-b0353104.pth',
+}
+
+
+def _make_divisible(v, divisor, min_value=None):
+    """
+    This function is taken from the original tf repo.
+    It ensures that all layers have a channel number that is divisible by 8
+    It can be seen here:
+    https://github.com/tensorflow/models/blob/master/research/slim/nets/mobilenet/mobilenet.py
+    :param v:
+    :param divisor:
+    :param min_value:
+    :return:
+    """
+    if min_value is None:
+        min_value = divisor
+    new_v = max(min_value, int(v + divisor / 2) // divisor * divisor)
+    # Make sure that round down does not go down by more than 10%.
+    if new_v < 0.9 * v:
+        new_v += divisor
+    return new_v
+
+
+class ConvBNReLU(nn.Sequential):
+    def __init__(self, in_planes, out_planes, kernel_size=3, stride=1, groups=1):
+        padding = (kernel_size - 1) // 2
+        super(ConvBNReLU, self).__init__(
+            nn.Conv2d(in_planes, out_planes, kernel_size, stride, padding, groups=groups, bias=False),
+            nn.BatchNorm2d(out_planes),
+            nn.ReLU6(inplace=True)
+        )
+
+
+class InvertedResidual(nn.Module):
+    def __init__(self, inp, oup, stride, expand_ratio):
+        super(InvertedResidual, self).__init__()
+        self.stride = stride
+        assert stride in [1, 2]
+
+        hidden_dim = int(round(inp * expand_ratio))
+        self.use_res_connect = self.stride == 1 and inp == oup
+
+        layers = []
+        if expand_ratio != 1:
+            # pw
+            layers.append(ConvBNReLU(inp, hidden_dim, kernel_size=1))
+        layers.extend([
+            # dw
+            ConvBNReLU(hidden_dim, hidden_dim, stride=stride, groups=hidden_dim),
+            # pw-linear
+            nn.Conv2d(hidden_dim, oup, 1, 1, 0, bias=False),
+            nn.BatchNorm2d(oup),
+        ])
+        self.conv = nn.Sequential(*layers)
+
+    def forward(self, x):
+        if self.use_res_connect:
+            return x + self.conv(x)
+        else:
+            return self.conv(x)
+
+
+class MobileNetV2(nn.Module):
+    def __init__(self, num_classes=1000, width_mult=1.0, inverted_residual_setting=None, round_nearest=8):
+        """
+        MobileNet V2 main class
+        Args:
+            num_classes (int): Number of classes
+            width_mult (float): Width multiplier - adjusts number of channels in each layer by this amount
+            inverted_residual_setting: Network structure
+            round_nearest (int): Round the number of channels in each layer to be a multiple of this number
+            Set to 1 to turn off rounding
+        """
+        super(MobileNetV2, self).__init__()
+        block = InvertedResidual
+        input_channel = 32
+        last_channel = 1280
+
+        if inverted_residual_setting is None:
+            inverted_residual_setting = [
+                # t, c, n, s
+                [1, 16, 1, 1],
+                [6, 24, 2, 2],
+                [6, 32, 3, 2],
+                [6, 64, 4, 2],
+                [6, 96, 3, 1],
+                [6, 160, 3, 2],
+                [6, 320, 1, 1],
+            ]
+
+        # only check the first element, assuming user knows t,c,n,s are required
+        if len(inverted_residual_setting) == 0 or len(inverted_residual_setting[0]) != 4:
+            raise ValueError("inverted_residual_setting should be non-empty "
+                             "or a 4-element list, got {}".format(inverted_residual_setting))
+
+        # building first layer
+        input_channel = _make_divisible(input_channel * width_mult, round_nearest)
+        self.last_channel = _make_divisible(last_channel * max(1.0, width_mult), round_nearest)
+        features = [ConvBNReLU(3, input_channel, stride=2)]
+        # building inverted residual blocks
+        for t, c, n, s in inverted_residual_setting:
+            output_channel = _make_divisible(c * width_mult, round_nearest)
+            for i in range(n):
+                stride = s if i == 0 else 1
+                features.append(block(input_channel, output_channel, stride, expand_ratio=t))
+                input_channel = output_channel
+        # building last several layers
+        features.append(ConvBNReLU(input_channel, self.last_channel, kernel_size=1))
+        # make it nn.Sequential
+        self.features = nn.Sequential(*features)
+
+        # building classifier
+        self.classifier = nn.Sequential(
+            nn.Dropout(0.2),
+            nn.Linear(self.last_channel, num_classes),
+        )
+
+        # weight initialization
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode='fan_out')
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+            elif isinstance(m, nn.BatchNorm2d):
+                nn.init.ones_(m.weight)
+                nn.init.zeros_(m.bias)
+            elif isinstance(m, nn.Linear):
+                nn.init.normal_(m.weight, 0, 0.01)
+                nn.init.zeros_(m.bias)
+
+    def forward(self, x):
+        x = self.features(x)
+        #x = x.mean([2, 3])
+        #x = self.classifier(x)
+        return x
+
+
+def mobilenet_v2(pretrained=False, progress=True, **kwargs):
+    """
+    Constructs a MobileNetV2 architecture from
+    `"MobileNetV2: Inverted Residuals and Linear Bottlenecks" <https://arxiv.org/abs/1801.04381>`_.
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    model = MobileNetV2(**kwargs)
+    if pretrained:
+        state_dict = load_state_dict_from_url(model_urls['mobilenet_v2'],
+                                              progress=progress)
+        model.load_state_dict(state_dict)
+    return model

--- a/examples/quantization_aware_training/models.py
+++ b/examples/quantization_aware_training/models.py
@@ -1,0 +1,40 @@
+import torch
+import torch.nn as nn
+
+class vanilla_cnn(nn.Module):
+    """
+    Contains basic conv ops for cifar-10 dataset
+    """
+    def __init__(self):
+        super().__init__()
+
+        self.convs = nn.Sequential(
+            nn.Conv2d(in_channels=3,out_channels=32,kernel_size=3,padding=1),
+            nn.BatchNorm2d(32),
+            nn.ReLU(),
+            nn.Conv2d(in_channels=32,out_channels=64,kernel_size=3,padding=1),
+            nn.BatchNorm2d(64),
+            nn.ReLU(),
+            nn.Conv2d(in_channels=64,out_channels=128,kernel_size=3,padding=1),
+            nn.BatchNorm2d(128),
+            nn.ReLU(),
+            nn.Conv2d(in_channels=128,out_channels=256,kernel_size=3,padding=1),
+            nn.BatchNorm2d(256),
+            nn.ReLU(),
+            nn.MaxPool2d(kernel_size=2,stride=8)
+        )
+
+        self.fcs = nn.Sequential(
+            nn.Linear(4096,1024),
+            nn.ReLU(),
+            nn.Linear(1024,512),
+            nn.ReLU(),
+            nn.Linear(512,10)
+        )
+    
+    def forward(self, x):
+
+        x = self.convs(x)
+        x = x.view(x.size(0),-1)
+        x = self.fcs(x)
+        return x 

--- a/examples/quantization_aware_training/parser.py
+++ b/examples/quantization_aware_training/parser.py
@@ -1,0 +1,24 @@
+import argparse
+
+def parse_args():
+    """
+    """
+    parser = argparse.ArgumentParser(description='PyTorch QAT')
+    parser.add_argument('--m','--model_name',default='vanilla_cnn',help="Name of the model")
+    parser.add_argument('--b', '--batch_size', default=32, type=int, help='mini-batch size (default: 32)')
+    parser.add_argument('--optimizer', default='Adam', type=str,help='type of optimizer (default=Adam)')
+    parser.add_argument( '--wd','--weight-decay', default=1e-5, type=float, help='weight decay (default: 1e-5)')
+    parser.add_argument('--start_epoch','--s_ep', default=0, type=int, help='starting epoch')
+    parser.add_argument('--num_epochs',default=30,type=int, help='no of epochs')
+    parser.add_argument('--no_cuda', action='store_true',help='disables cuda training')
+    parser.add_argument('--seed', type=int, default=12345,help='random seed for experiments. [default: 12345]')
+    parser.add_argument('--lr', '--learning_rate', default=1e-2, type=float, help='initial learning rate')
+    parser.add_argument('--lrdt', '--learning_rate_decay_interval', default=30, type=int, help='initial learning rate decay after n epochs')
+    parser.add_argument('--od','--output_dir', default='/tmp/',help='output path')
+    parser.add_argument('--en','--exp_name', default='pytorch_exp',help = 'experiment name to create output dir')
+    parser.add_argument('--load_ckpt', default = None, help = "path to ckpt")
+    parser.add_argument('--netqat',action='store_true',help = 'quantize model using custom layer')
+    parser.add_argument('--partial_ckpt',action='store_true',help = 'load_partial checkpoint')
+    parser.add_argument('--v','--verbose',action='store_true')
+    args = parser.parse_args()
+    return args

--- a/examples/quantization_aware_training/parser.py
+++ b/examples/quantization_aware_training/parser.py
@@ -4,6 +4,7 @@ def parse_args():
     """
     """
     parser = argparse.ArgumentParser(description='PyTorch QAT')
+    parser.add_argument('--hack_dynamic_range',action='store_true')
     parser.add_argument('--m','--model_name',default='resnet18',help="Name of the model")
     parser.add_argument('--b', '--batch_size', default=32, type=int, help='mini-batch size (default: 32)')
     parser.add_argument('--optimizer', default='Adam', type=str,help='type of optimizer (default=Adam)')

--- a/examples/quantization_aware_training/parser.py
+++ b/examples/quantization_aware_training/parser.py
@@ -4,7 +4,7 @@ def parse_args():
     """
     """
     parser = argparse.ArgumentParser(description='PyTorch QAT')
-    parser.add_argument('--m','--model_name',default='vanilla_cnn',help="Name of the model")
+    parser.add_argument('--m','--model_name',default='resnet18',help="Name of the model")
     parser.add_argument('--b', '--batch_size', default=32, type=int, help='mini-batch size (default: 32)')
     parser.add_argument('--optimizer', default='Adam', type=str,help='type of optimizer (default=Adam)')
     parser.add_argument( '--wd','--weight-decay', default=1e-5, type=float, help='weight decay (default: 1e-5)')

--- a/examples/quantization_aware_training/resnet.py
+++ b/examples/quantization_aware_training/resnet.py
@@ -94,7 +94,6 @@ class Bottleneck(nn.Module):
 
     def forward(self, x):
         identity = x
-        out = self.relu(x) ## added dummy relu so that first conv can go to int8
         out = self.conv1(out)
         out = self.bn1(out)
         out = self.relu(out)
@@ -193,6 +192,7 @@ class ResNet(nn.Module):
         return nn.Sequential(*layers)
 
     def forward(self, x):
+        x = self.relu(x)
         x = self.conv1(x)
         x = self.bn1(x)
         x = self.relu(x)

--- a/examples/quantization_aware_training/resnet.py
+++ b/examples/quantization_aware_training/resnet.py
@@ -1,0 +1,344 @@
+import torch
+import torch.nn as nn
+#from .utils import load_state_dict_from_url
+
+
+__all__ = ['ResNet', 'resnet18', 'resnet34', 'resnet50', 'resnet101',
+           'resnet152', 'resnext50_32x4d', 'resnext101_32x8d',
+           'wide_resnet50_2', 'wide_resnet101_2']
+
+
+model_urls = {
+    'resnet18': 'https://download.pytorch.org/models/resnet18-5c106cde.pth',
+    'resnet34': 'https://download.pytorch.org/models/resnet34-333f7ec4.pth',
+    'resnet50': 'https://download.pytorch.org/models/resnet50-19c8e357.pth',
+    'resnet101': 'https://download.pytorch.org/models/resnet101-5d3b4d8f.pth',
+    'resnet152': 'https://download.pytorch.org/models/resnet152-b121ed2d.pth',
+    'resnext50_32x4d': 'https://download.pytorch.org/models/resnext50_32x4d-7cdf4587.pth',
+    'resnext101_32x8d': 'https://download.pytorch.org/models/resnext101_32x8d-8ba56ff5.pth',
+    'wide_resnet50_2': 'https://download.pytorch.org/models/wide_resnet50_2-95faca4d.pth',
+    'wide_resnet101_2': 'https://download.pytorch.org/models/wide_resnet101_2-32ee1156.pth',
+}
+
+
+def conv3x3(in_planes, out_planes, stride=1, groups=1, dilation=1):
+    """3x3 convolution with padding"""
+    return nn.Conv2d(in_planes, out_planes, kernel_size=3, stride=stride,
+                     padding=dilation, groups=groups, bias=False, dilation=dilation)
+
+
+def conv1x1(in_planes, out_planes, stride=1):
+    """1x1 convolution"""
+    return nn.Conv2d(in_planes, out_planes, kernel_size=1, stride=stride, bias=False)
+
+
+class BasicBlock(nn.Module):
+    expansion = 1
+
+    def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,
+                 base_width=64, dilation=1, norm_layer=None):
+        super(BasicBlock, self).__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        if groups != 1 or base_width != 64:
+            raise ValueError('BasicBlock only supports groups=1 and base_width=64')
+        if dilation > 1:
+            raise NotImplementedError("Dilation > 1 not supported in BasicBlock")
+        # Both self.conv1 and self.downsample layers downsample the input when stride != 1
+        self.conv1 = conv3x3(inplanes, planes, stride)
+        self.bn1 = norm_layer(planes)
+        self.relu = nn.ReLU(inplace=True)
+        self.conv2 = conv3x3(planes, planes)
+        self.bn2 = norm_layer(planes)
+        self.downsample = downsample
+        self.stride = stride
+
+    def forward(self, x):
+        identity = x
+
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+
+        if self.downsample is not None:
+            identity = self.downsample(x)
+
+        out += identity
+        out = self.relu(out)
+
+        return out
+
+
+class Bottleneck(nn.Module):
+    expansion = 4
+
+    def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,
+                 base_width=64, dilation=1, norm_layer=None):
+        super(Bottleneck, self).__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        width = int(planes * (base_width / 64.)) * groups
+        # Both self.conv2 and self.downsample layers downsample the input when stride != 1
+        self.conv1 = conv1x1(inplanes, width)
+        self.bn1 = norm_layer(width)
+        self.conv2 = conv3x3(width, width, stride, groups, dilation)
+        self.bn2 = norm_layer(width)
+        self.conv3 = conv1x1(width, planes * self.expansion)
+        self.bn3 = norm_layer(planes * self.expansion)
+        self.relu = nn.ReLU(inplace=True)
+        self.downsample = downsample
+        self.stride = stride
+
+    def forward(self, x):
+        identity = x
+
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+        out = self.relu(out)
+
+        out = self.conv3(out)
+        out = self.bn3(out)
+
+        if self.downsample is not None:
+            identity = self.downsample(x)
+
+        out += identity
+        out = self.relu(out)
+
+        return out
+
+
+class ResNet(nn.Module):
+
+    def __init__(self, block, layers, num_classes=1000, zero_init_residual=False,
+                 groups=1, width_per_group=64, replace_stride_with_dilation=None,
+                 norm_layer=None):
+        super(ResNet, self).__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        self._norm_layer = norm_layer
+
+        self.inplanes = 64
+        self.dilation = 1
+        if replace_stride_with_dilation is None:
+            # each element in the tuple indicates if we should replace
+            # the 2x2 stride with a dilated convolution instead
+            replace_stride_with_dilation = [False, False, False]
+        if len(replace_stride_with_dilation) != 3:
+            raise ValueError("replace_stride_with_dilation should be None "
+                             "or a 3-element tuple, got {}".format(replace_stride_with_dilation))
+        self.groups = groups
+        self.base_width = width_per_group
+        self.conv1 = nn.Conv2d(3, self.inplanes, kernel_size=7, stride=2, padding=3,
+                               bias=False)
+        self.bn1 = norm_layer(self.inplanes)
+        self.relu = nn.ReLU(inplace=True)
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+        self.layer1 = self._make_layer(block, 64, layers[0])
+        self.layer2 = self._make_layer(block, 128, layers[1], stride=2,
+                                       dilate=replace_stride_with_dilation[0])
+        self.layer3 = self._make_layer(block, 256, layers[2], stride=2,
+                                       dilate=replace_stride_with_dilation[1])
+        self.layer4 = self._make_layer(block, 512, layers[3], stride=2,
+                                       dilate=replace_stride_with_dilation[2])
+        self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
+        self.fc = nn.Linear(512 * block.expansion, num_classes)
+
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+            elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+
+        # Zero-initialize the last BN in each residual branch,
+        # so that the residual branch starts with zeros, and each residual block behaves like an identity.
+        # This improves the model by 0.2~0.3% according to https://arxiv.org/abs/1706.02677
+        if zero_init_residual:
+            for m in self.modules():
+                if isinstance(m, Bottleneck):
+                    nn.init.constant_(m.bn3.weight, 0)
+                elif isinstance(m, BasicBlock):
+                    nn.init.constant_(m.bn2.weight, 0)
+
+    def _make_layer(self, block, planes, blocks, stride=1, dilate=False):
+        norm_layer = self._norm_layer
+        downsample = None
+        previous_dilation = self.dilation
+        if dilate:
+            self.dilation *= stride
+            stride = 1
+        if stride != 1 or self.inplanes != planes * block.expansion:
+            downsample = nn.Sequential(
+                conv1x1(self.inplanes, planes * block.expansion, stride),
+                norm_layer(planes * block.expansion),
+            )
+
+        layers = []
+        layers.append(block(self.inplanes, planes, stride, downsample, self.groups,
+                            self.base_width, previous_dilation, norm_layer))
+        self.inplanes = planes * block.expansion
+        for _ in range(1, blocks):
+            layers.append(block(self.inplanes, planes, groups=self.groups,
+                                base_width=self.base_width, dilation=self.dilation,
+                                norm_layer=norm_layer))
+
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.bn1(x)
+        x = self.relu(x)
+        x = self.maxpool(x)
+
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+
+        #x = self.avgpool(x)
+        #x = torch.flatten(x, 1)
+        #x = self.fc(x)
+
+        return x
+
+
+def _resnet(arch, block, layers, pretrained, progress, **kwargs):
+    model = ResNet(block, layers, **kwargs)
+    if pretrained:
+        state_dict = load_state_dict_from_url(model_urls[arch],
+                                              progress=progress)
+        model.load_state_dict(state_dict)
+    return model
+
+
+def resnet18(pretrained=False, progress=True, **kwargs):
+    r"""ResNet-18 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>'_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _resnet('resnet18', BasicBlock, [2, 2, 2, 2], pretrained, progress,
+                   **kwargs)
+
+
+def resnet34(pretrained=False, progress=True, **kwargs):
+    r"""ResNet-34 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>'_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _resnet('resnet34', BasicBlock, [3, 4, 6, 3], pretrained, progress,
+                   **kwargs)
+
+
+def resnet50(pretrained=False, progress=True, **kwargs):
+    r"""ResNet-50 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>'_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _resnet('resnet50', Bottleneck, [3, 4, 6, 3], pretrained, progress,
+                   **kwargs)
+
+
+def resnet101(pretrained=False, progress=True, **kwargs):
+    r"""ResNet-101 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>'_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _resnet('resnet101', Bottleneck, [3, 4, 23, 3], pretrained, progress,
+                   **kwargs)
+
+
+def resnet152(pretrained=False, progress=True, **kwargs):
+    r"""ResNet-152 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>'_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _resnet('resnet152', Bottleneck, [3, 8, 36, 3], pretrained, progress,
+                   **kwargs)
+
+
+def resnext50_32x4d(pretrained=False, progress=True, **kwargs):
+    r"""ResNeXt-50 32x4d model from
+    `"Aggregated Residual Transformation for Deep Neural Networks" <https://arxiv.org/pdf/1611.05431.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    kwargs['groups'] = 32
+    kwargs['width_per_group'] = 4
+    return _resnet('resnext50_32x4d', Bottleneck, [3, 4, 6, 3],
+                   pretrained, progress, **kwargs)
+
+
+def resnext101_32x8d(pretrained=False, progress=True, **kwargs):
+    r"""ResNeXt-101 32x8d model from
+    `"Aggregated Residual Transformation for Deep Neural Networks" <https://arxiv.org/pdf/1611.05431.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    kwargs['groups'] = 32
+    kwargs['width_per_group'] = 8
+    return _resnet('resnext101_32x8d', Bottleneck, [3, 4, 23, 3],
+                   pretrained, progress, **kwargs)
+
+
+def wide_resnet50_2(pretrained=False, progress=True, **kwargs):
+    r"""Wide ResNet-50-2 model from
+    `"Wide Residual Networks" <https://arxiv.org/pdf/1605.07146.pdf>`_
+
+    The model is the same as ResNet except for the bottleneck number of channels
+    which is twice larger in every block. The number of channels in outer 1x1
+    convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
+    channels, and in Wide ResNet-50-2 has 2048-1024-2048.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    kwargs['width_per_group'] = 64 * 2
+    return _resnet('wide_resnet50_2', Bottleneck, [3, 4, 6, 3],
+                   pretrained, progress, **kwargs)
+
+
+def wide_resnet101_2(pretrained=False, progress=True, **kwargs):
+    r"""Wide ResNet-101-2 model from
+    `"Wide Residual Networks" <https://arxiv.org/pdf/1605.07146.pdf>`_
+
+    The model is the same as ResNet except for the bottleneck number of channels
+    which is twice larger in every block. The number of channels in outer 1x1
+    convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
+    channels, and in Wide ResNet-50-2 has 2048-1024-2048.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    kwargs['width_per_group'] = 64 * 2
+    return _resnet('wide_resnet101_2', Bottleneck, [3, 4, 23, 3],
+                   pretrained, progress, **kwargs)
+

--- a/examples/quantization_aware_training/resnet.py
+++ b/examples/quantization_aware_training/resnet.py
@@ -94,8 +94,8 @@ class Bottleneck(nn.Module):
 
     def forward(self, x):
         identity = x
-
-        out = self.conv1(x)
+        out = self.relu(x) ## added dummy relu so that first conv can go to int8
+        out = self.conv1(out)
         out = self.bn1(out)
         out = self.relu(out)
 

--- a/torch2trt/converters/AdaptiveAvgPool2d.py
+++ b/torch2trt/converters/AdaptiveAvgPool2d.py
@@ -20,13 +20,15 @@ def convert_AdaptiveAvgPool2d(ctx):
     layer = ctx.network.add_pooling(
         input=input_trt, type=trt.PoolingType.AVERAGE, window_size=kernel_size)
     layer.stride = stride
-    amax = 5 
-    layer.precision = trt.int8
-    layer.set_output_type(0,trt.int8)
-    out = layer.get_output(0)
-    out.dynamic_range=(-amax,amax)
-    print("adaptive avgpool") 
-    output._trt = out  
+
+    if ctx.hack_dynamic_range:
+        amax = 5 
+        layer.precision = trt.int8
+        layer.set_output_type(0,trt.int8)
+        out = layer.get_output(0)
+        out.dynamic_range=(-amax,amax)
+        print("adaptive avgpool") 
+    output._trt = layer.get_output(0)
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 224, 224)])

--- a/torch2trt/converters/AdaptiveAvgPool2d.py
+++ b/torch2trt/converters/AdaptiveAvgPool2d.py
@@ -25,7 +25,7 @@ def convert_AdaptiveAvgPool2d(ctx):
     layer.set_output_type(0,trt.int8)
     out = layer.get_output(0)
     out.dynamic_range=(-amax,amax)
- 
+    print("adaptive avgpool") 
     output._trt = out  
 
 

--- a/torch2trt/converters/AdaptiveAvgPool2d.py
+++ b/torch2trt/converters/AdaptiveAvgPool2d.py
@@ -20,8 +20,13 @@ def convert_AdaptiveAvgPool2d(ctx):
     layer = ctx.network.add_pooling(
         input=input_trt, type=trt.PoolingType.AVERAGE, window_size=kernel_size)
     layer.stride = stride
-
-    output._trt = layer.get_output(0)
+    amax = 5 
+    layer.precision = trt.int8
+    layer.set_output_type(0,trt.int8)
+    out = layer.get_output(0)
+    out.dynamic_range=(-amax,amax)
+ 
+    output._trt = out  
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 224, 224)])

--- a/torch2trt/converters/BatchNorm1d.py
+++ b/torch2trt/converters/BatchNorm1d.py
@@ -27,7 +27,14 @@ def convert_BatchNorm2d(ctx):
     layer = ctx.network.add_shuffle(layer.get_output(0))
     layer.reshape_dims = tuple(output.shape[1:])
     
-    output._trt = layer.get_output(0)
+    amax = 4
+    layer.precision = trt.int8
+    layer.set_output_type(0,trt.int8)
+    out = layer.get_output(0)
+    out.dynamic_range=(-amax,amax)
+    print("BN1d")
+    
+    output._trt = out
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 10)])

--- a/torch2trt/converters/BatchNorm2d.py
+++ b/torch2trt/converters/BatchNorm2d.py
@@ -25,5 +25,5 @@ def convert_BatchNorm2d(ctx):
     layer.set_output_type(0,trt.int8)
     out = layer.get_output(0)
     out.dynamic_range=(-amax,amax)
-    print("BN")
+    print("BN2d")
     output._trt = out 

--- a/torch2trt/converters/BatchNorm2d.py
+++ b/torch2trt/converters/BatchNorm2d.py
@@ -25,5 +25,5 @@ def convert_BatchNorm2d(ctx):
     layer.set_output_type(0,trt.int8)
     out = layer.get_output(0)
     out.dynamic_range=(-amax,amax)
-
+    print("BN")
     output._trt = out 

--- a/torch2trt/converters/BatchNorm2d.py
+++ b/torch2trt/converters/BatchNorm2d.py
@@ -20,10 +20,10 @@ def convert_BatchNorm2d(ctx):
 
     layer = ctx.network.add_scale(input_trt, trt.ScaleMode.CHANNEL, bias, scale, power)
     
-    amax = 4 
-    layer.precision = trt.int8
-    layer.set_output_type(0,trt.int8)
-    out = layer.get_output(0)
-    out.dynamic_range=(-amax,amax)
+    #amax = 4 
+    #layer.precision = trt.int8
+    #layer.set_output_type(0,trt.int8)
+    #out = layer.get_output(0)
+    #out.dynamic_range=(-amax,amax)
     print("BN2d")
     output._trt = out 

--- a/torch2trt/converters/BatchNorm2d.py
+++ b/torch2trt/converters/BatchNorm2d.py
@@ -19,5 +19,11 @@ def convert_BatchNorm2d(ctx):
     power = np.ones_like(scale)
 
     layer = ctx.network.add_scale(input_trt, trt.ScaleMode.CHANNEL, bias, scale, power)
+    
+    amax = 4 
+    layer.precision = trt.int8
+    layer.set_output_type(0,trt.int8)
+    out = layer.get_output(0)
+    out.dynamic_range=(-amax,amax)
 
-    output._trt = layer.get_output(0)
+    output._trt = out 

--- a/torch2trt/converters/Conv.py
+++ b/torch2trt/converters/Conv.py
@@ -47,13 +47,14 @@ def convert_Conv_trt7(ctx):
     if module.groups is not None:
         layer.num_groups = module.groups
     
-    amax = 5
-    layer.precision = trt.int8
-    layer.set_output_type(0,trt.int8)
-    conv_out = layer.get_output(0)
-    conv_out.dynamic_range=(-amax,amax)
-    print("conv")
-    output._trt = layer.get_output(0)
+    if ctx.qat_mode:
+        amax = 5
+        layer.precision = trt.int8
+        layer.set_output_type(0,trt.int8)
+        conv_out = layer.get_output(0)
+        conv_out.dynamic_range=(-amax,amax)
+        print("conv")
+        output._trt = layer.get_output(0)
 
 
 

--- a/torch2trt/converters/Conv.py
+++ b/torch2trt/converters/Conv.py
@@ -52,7 +52,7 @@ def convert_Conv_trt7(ctx):
     layer.set_output_type(0,trt.int8)
     conv_out = layer.get_output(0)
     conv_out.dynamic_range=(-amax,amax)
-
+    print("conv")
     output._trt = layer.get_output(0)
 
 

--- a/torch2trt/converters/Conv.py
+++ b/torch2trt/converters/Conv.py
@@ -46,6 +46,12 @@ def convert_Conv_trt7(ctx):
 
     if module.groups is not None:
         layer.num_groups = module.groups
+    
+    amax = 5
+    layer.precision = trt.int8
+    layer.set_output_type(0,trt.int8)
+    conv_out = layer.get_output(0)
+    conv_out.dynamic_range=(-amax,amax)
 
     output._trt = layer.get_output(0)
 

--- a/torch2trt/converters/ConvTranspose.py
+++ b/torch2trt/converters/ConvTranspose.py
@@ -44,7 +44,13 @@ def convert_ConvTranspose2d_trt7(ctx):
     
     if module.groups is not None:
         layer.num_groups = module.groups
-
+    
+    amax = 5
+    layer.precision = trt.int8
+    layer.set_output_type(0,trt.int8)
+    out = layer.get_output(0)
+    out.dynamic_range=(-amax,amax)
+    print("ConvTranspose")
     output._trt = layer.get_output(0)
 
 

--- a/torch2trt/converters/ReLU.py
+++ b/torch2trt/converters/ReLU.py
@@ -8,11 +8,11 @@ def convert_ReLU(ctx):
     output = ctx.method_return
     layer = ctx.network.add_activation(
         input=input_trt, type=trt.ActivationType.RELU)
-    
-    amax = 5 
-    layer.precision = trt.int8
-    layer.set_output_type(0,trt.int8)
-    out = layer.get_output(0)
-    out.dynamic_range=(-amax,amax)
-    print("relu") 
-    output._trt = out
+    if ctx.qat_mode:    
+        amax = 5 
+        layer.precision = trt.int8
+        layer.set_output_type(0,trt.int8)
+        out = layer.get_output(0)
+        out.dynamic_range=(-amax,amax)
+        print("relu") 
+    output._trt = layer.get_output(0)

--- a/torch2trt/converters/ReLU.py
+++ b/torch2trt/converters/ReLU.py
@@ -14,5 +14,5 @@ def convert_ReLU(ctx):
     layer.set_output_type(0,trt.int8)
     out = layer.get_output(0)
     out.dynamic_range=(-amax,amax)
- 
+    print("relu") 
     output._trt = out

--- a/torch2trt/converters/ReLU.py
+++ b/torch2trt/converters/ReLU.py
@@ -8,4 +8,11 @@ def convert_ReLU(ctx):
     output = ctx.method_return
     layer = ctx.network.add_activation(
         input=input_trt, type=trt.ActivationType.RELU)
-    output._trt = layer.get_output(0)
+    
+    amax = 5 
+    layer.precision = trt.int8
+    layer.set_output_type(0,trt.int8)
+    out = layer.get_output(0)
+    out.dynamic_range=(-amax,amax)
+ 
+    output._trt = out

--- a/torch2trt/converters/ReLU6.py
+++ b/torch2trt/converters/ReLU6.py
@@ -14,6 +14,13 @@ def convert_ReLU6(ctx):
         input=input_a_trt, type=trt.ActivationType.RELU)
     layer = ctx.network.add_elementwise(
         layer.get_output(0), input_b_trt, trt.ElementWiseOperation.MIN)
+    
+    amax = 5
+    layer.precision = trt.int8
+    layer.set_output_type(0,trt.int8)
+    out = layer.get_output(0)
+    out.dynamic_range=(-amax,amax)
+    print("relu6")
 
     output._trt = layer.get_output(0)
     

--- a/torch2trt/converters/adaptive_max_pool2d.py
+++ b/torch2trt/converters/adaptive_max_pool2d.py
@@ -17,8 +17,14 @@ def convert_adaptive_max_pool2d(ctx):
     layer = ctx.network.add_pooling(
         input=input._trt, type=trt.PoolingType.MAX, window_size=kernel_size)
     layer.stride = stride
-
-    output._trt = layer.get_output(0)
+    
+    amax = 5 
+    layer.precision = trt.int8
+    layer.set_output_type(0,trt.int8)
+    out = layer.get_output(0)
+    out.dynamic_range=(-amax,amax)
+ 
+    output._trt = out 
 
     
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 224, 224)])

--- a/torch2trt/converters/add.py
+++ b/torch2trt/converters/add.py
@@ -13,7 +13,14 @@ def convert_add(ctx):
     input_a_trt, input_b_trt = add_missing_trt_tensors(ctx.network, [input_a, input_b])
     input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], len(output.shape) - 1)
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, trt.ElementWiseOperation.SUM)
-    output._trt = layer.get_output(0)
+    
+    amax = 2 
+    layer.precision = trt.int8
+    layer.set_output_type(0,trt.int8)
+    out = layer.get_output(0)
+    out.dynamic_range=(-amax,amax)
+ 
+    output._trt = out 
     
 
 class Add(torch.nn.Module):

--- a/torch2trt/converters/add.py
+++ b/torch2trt/converters/add.py
@@ -19,7 +19,7 @@ def convert_add(ctx):
     layer.set_output_type(0,trt.int8)
     out = layer.get_output(0)
     out.dynamic_range=(-amax,amax)
- 
+    print("add") 
     output._trt = out 
     
 

--- a/torch2trt/converters/add.py
+++ b/torch2trt/converters/add.py
@@ -14,13 +14,14 @@ def convert_add(ctx):
     input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], len(output.shape) - 1)
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, trt.ElementWiseOperation.SUM)
     
-    amax = 2 
-    layer.precision = trt.int8
-    layer.set_output_type(0,trt.int8)
-    out = layer.get_output(0)
-    out.dynamic_range=(-amax,amax)
-    print("add") 
-    output._trt = out 
+    if ctx.hack_dynamic_range:
+        amax = 2 
+        layer.precision = trt.int8
+        layer.set_output_type(0,trt.int8)
+        out = layer.get_output(0)
+        out.dynamic_range=(-amax,amax)
+        print("add") 
+    output._trt = layer.get_output(0)
     
 
 class Add(torch.nn.Module):

--- a/torch2trt/converters/batch_norm.py
+++ b/torch2trt/converters/batch_norm.py
@@ -20,7 +20,16 @@ def convert_batch_norm_trt7(ctx):
     power = np.ones_like(scale)
     
     layer = ctx.network.add_scale_nd(input_trt, trt.ScaleMode.CHANNEL, bias, scale, power, 0)
+    if ctx.hack_dynamic_range:
+        amax = 4
+        layer.precision = trt.int8
+        layer.set_output_type(0,trt.int8)
+        out = layer.get_output(0)
+        out.dynamic_range=(-amax,amax)
+        print("BN")
+
     output._trt = layer.get_output(0)
+
 
 
 

--- a/torch2trt/converters/max_pool2d.py
+++ b/torch2trt/converters/max_pool2d.py
@@ -37,8 +37,14 @@ def convert_max_pool2d(ctx):
     
     if ceil_mode:
         layer.padding_mode = trt.PaddingMode.EXPLICIT_ROUND_UP
-
-    output._trt = layer.get_output(0)
+    
+    amax = 5 
+    layer.precision = trt.int8
+    layer.set_output_type(0,trt.int8)
+    out = layer.get_output(0)
+    out.dynamic_range=(-amax,amax)
+ 
+    output._trt = out 
     
     
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 4, 6)])

--- a/torch2trt/converters/max_pool2d.py
+++ b/torch2trt/converters/max_pool2d.py
@@ -43,7 +43,7 @@ def convert_max_pool2d(ctx):
     layer.set_output_type(0,trt.int8)
     out = layer.get_output(0)
     out.dynamic_range=(-amax,amax)
- 
+    print("MaxPool2d") 
     output._trt = out 
     
     

--- a/torch2trt/converters/view.py
+++ b/torch2trt/converters/view.py
@@ -15,14 +15,14 @@ def convert_view(ctx):
     output = ctx.method_return
     layer = ctx.network.add_shuffle(input_trt)
     layer.reshape_dims = tuple(output.shape[1:])
-    
-    amax = 5
-    layer.precision = trt.int8
-    layer.set_output_type(0,trt.int8)
-    out = layer.get_output(0)
-    out.dynamic_range=(-amax,amax)
-    print("view")
-    output._trt = out
+    if ctx.hack_dynamic_range:    
+        amax = 5
+        layer.precision = trt.int8
+        layer.set_output_type(0,trt.int8)
+        out = layer.get_output(0)
+        out.dynamic_range=(-amax,amax)
+        print("view")
+    output._trt = layer.get_output(0)
 
 
 class View(torch.nn.Module):

--- a/torch2trt/converters/view.py
+++ b/torch2trt/converters/view.py
@@ -15,7 +15,14 @@ def convert_view(ctx):
     output = ctx.method_return
     layer = ctx.network.add_shuffle(input_trt)
     layer.reshape_dims = tuple(output.shape[1:])
-    output._trt = layer.get_output(0)
+    
+    amax = 5
+    layer.precision = trt.int8
+    layer.set_output_type(0,trt.int8)
+    out = layer.get_output(0)
+    out.dynamic_range=(-amax,amax)
+    print("view")
+    output._trt = out
 
 
 class View(torch.nn.Module):

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -488,7 +488,8 @@ def torch2trt(module,
               max_workspace_size=1<<25, 
               strict_type_constraints=False, 
               keep_network=True, 
-              int8_mode=False, 
+              int8_mode=False,
+              qat_mode=False,
               int8_calib_dataset=None,
               int8_calib_algorithm=DEFAULT_CALIBRATION_ALGORITHM,
               int8_calib_batch_size=1,
@@ -551,11 +552,11 @@ def torch2trt(module,
             int8_calib_dataset = TensorBatchDataset(inputs_in)
 
         builder.int8_mode = True
-
+        if not qat_mode:
         # @TODO(jwelsh):  Should we set batch_size=max_batch_size?  Need to investigate memory consumption
-        builder.int8_calibrator = DatasetCalibrator(
-            inputs, int8_calib_dataset, batch_size=int8_calib_batch_size, algorithm=int8_calib_algorithm
-        )
+            builder.int8_calibrator = DatasetCalibrator(
+                inputs, int8_calib_dataset, batch_size=int8_calib_batch_size, algorithm=int8_calib_algorithm
+            )
 
     engine = builder.build_cuda_engine(network)
 

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -534,6 +534,7 @@ def torch2trt(module,
         with ConversionContext(network) as ctx:
 
             ctx.add_inputs(inputs, input_names)
+            ctx.qat_mode=qat_mode
             ctx.hack_dynamic_range=hack_dynamic_range
             outputs = module(*inputs)
 

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -490,6 +490,7 @@ def torch2trt(module,
               keep_network=True, 
               int8_mode=False,
               qat_mode=False,
+              hack_dynamic_range=False,
               int8_calib_dataset=None,
               int8_calib_algorithm=DEFAULT_CALIBRATION_ALGORITHM,
               int8_calib_batch_size=1,
@@ -533,7 +534,7 @@ def torch2trt(module,
         with ConversionContext(network) as ctx:
 
             ctx.add_inputs(inputs, input_names)
-
+            ctx.hack_dynamic_range=hack_dynamic_range
             outputs = module(*inputs)
 
             if not isinstance(outputs, tuple) and not isinstance(outputs, list):


### PR DESCRIPTION
**This PR shows that every layer in the model needs to have a dynamic range for QAT for TRT7 otherwise most layers will fallback to FP32/FP16**

Following operators carry dynamic range with them

1. Conv
2. ReLU
3. ConvTranspose2d

However, there are some layers that dont carry dynamic range with them

1. BN (as it should be folded into conv during inference)
2. Add (if immediately followed by a relu because it will be absorbed during inference)

Following experiments show that 
1. When I dont put the dynamic range for BN/ Add for Resnet18 and MobilenetV2, majority of the Conv layers even though they have their respective dynamic range fallback to FP32/FP16

2. When I explicitly add the dynamic range in for BN and Add operators, then I don't see the problem


**Usage**

1. Build torch2trt with this PR
2. cd `examples/quantization_aware_training`
3. 

**Run without hacking dynamic ranges (a lot of conv layers will fallback)**

`python infer.py --m resnet18/mobilenet `

**Run with hack:**

`python infer.py --m resnet18/mobilenet --hack_dynamic_range`
