### PR TITLE
Bug Fixed: The incorrect calculation method of kernel_size in adaptive pooling2d

### DIFF
--- a/torch2trt/converters/AdaptiveAvgPool2d.py
+++ b/torch2trt/converters/AdaptiveAvgPool2d.py
@@ -16,7 +16,7 @@ def convert_AdaptiveAvgPool2d(ctx):
 
     stride = (input_trt.shape[-2] // output_size[-2], input_trt.shape[-1] // output_size[-1])
 
-    kernel_size = stride
+    kernel_size = (input_trt.shape[-2] - (output_size[-2] - 1) * stride[-2], input_trt.shape[-1] - (output_size[-1] - 1) * stride[-1])
     layer = ctx.network.add_pooling(
         input=input_trt, type=trt.PoolingType.AVERAGE, window_size=kernel_size)
     layer.stride = stride

--- a/torch2trt/converters/adaptive_max_pool2d.py
+++ b/torch2trt/converters/adaptive_max_pool2d.py
@@ -13,7 +13,7 @@ def convert_adaptive_max_pool2d(ctx):
 
     stride = (input._trt.shape[-2] // output_size[-2], input._trt.shape[-1] // output_size[-1])
 
-    kernel_size = stride
+    kernel_size = (input.trt.shape[-2] - (output_size[-2] - 1) * stride[-2], input.trt.shape[-1] - (output_size[-1] - 1) * stride[-1])
     layer = ctx.network.add_pooling(
         input=input._trt, type=trt.PoolingType.MAX, window_size=kernel_size)
     layer.stride = stride


### PR DESCRIPTION
Hi, 
It gave me an error, when I test the adaptive pool2d with input of shape [(1, 1, 10, 10)] and output_size is [6, 6].  As below:
```
| Name | Data Type | Input Shapes | torch2trt kwargs | Max Error | Throughput (PyTorch) | Throughput (TensorRT) | Latency (PyTorch) | Latency (TensorRT) |
|------|-----------|--------------|------------------|-----------|----------------------|-----------------------|-------------------|--------------------|
| torch2trt.converters.adaptive_max_pool2d.test_adaptive_max_pool2d_6x6 | float32 | [(1, 1, 10, 10)] | {} | N/A | N/A | N/A | N/A | N/A |
```

The cause of this bug is the incorrect calculation method of kernel_size.

However, this calculation method of adaptive pool2d is still mismatch with pytorch [max error is large, shown as below]. 

```
| Name | Data Type | Input Shapes | torch2trt kwargs | Max Error | Throughput (PyTorch) | Throughput (TensorRT) | Latency (PyTorch) | Latency (TensorRT) |
|------|-----------|--------------|------------------|-----------|----------------------|-----------------------|-------------------|--------------------|
| torch2trt.converters.adaptive_max_pool2d.test_adaptive_max_pool2d_6x6 | float32 | [(1, 1, 10, 10)] | {} | 5.00E+00 | 2.01e+04 | 6.91e+03 | 0.0673 | 0.155 |
```

TODO: Re-implement the adaptive pool2d 

Best,
Fei-Fei