### PR TITLE
wheel build fails in docker image due to nvidia runtime not available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 import sys
-import torch
 from setuptools import setup, find_packages
-from torch.utils.cpp_extension import BuildExtension, CUDAExtension, CppExtension
 
 def trt_inc_dir():
     return "/usr/include/aarch64-linux-gnu"
@@ -11,29 +9,39 @@ def trt_lib_dir():
 
 ext_modules = []
 
-plugins_ext_module = CUDAExtension(
-        name='plugins', 
-        sources=[
-            'torch2trt/plugins/plugins.cpp'
-        ],
-        include_dirs=[
-            trt_inc_dir()
-        ],
-        library_dirs=[
-            trt_lib_dir()
-        ],
-        libraries=[
-            'nvinfer'
-        ],
-        extra_compile_args={
-            'cxx': ['-DUSE_DEPRECATED_INTLIST'] if torch.__version__ < "1.5" else [],
-            'nvcc': []
-        }
-    )
 if '--plugins' in sys.argv:
+    import torch
+    from torch.utils.cpp_extension import CUDAExtension
+    plugins_ext_module = CUDAExtension(
+            name='plugins',
+            sources=[
+                'torch2trt/plugins/plugins.cpp'
+            ],
+            include_dirs=[
+                trt_inc_dir()
+            ],
+            library_dirs=[
+                trt_lib_dir()
+            ],
+            libraries=[
+                'nvinfer'
+            ],
+            extra_compile_args={
+                'cxx': ['-DUSE_DEPRECATED_INTLIST'] if torch.__version__ < "1.5" else [],
+                'nvcc': []
+            }
+        )
     ext_modules.append(plugins_ext_module)
     sys.argv.remove('--plugins')
-    
+
+
+def get_cmdclass():
+    if '--plugins' in sys.argv:
+        from torch.utils.cpp_extension import BuildExtension
+        return {'build_ext': BuildExtension}
+    else:
+        return {}
+
 
 setup(
     name='torch2trt',
@@ -42,5 +50,6 @@ setup(
     packages=find_packages(),
     ext_package='torch2trt',
     ext_modules=ext_modules,
-    cmdclass={'build_ext': BuildExtension}
+    cmdclass=get_cmdclass()
 )
+


### PR DESCRIPTION
If the library gets cloned/installed inside a docker image, the nvidia runtime isn't available, resulting in the following error:
```
OSError: libcurand.so.10: cannot open shared object file: No such file or directory
```
This stems from the `torch` import in the `setup.py` file, which will attempt to load the CUDA libraries.

By making the torch import/use conditional to the `--plugins` flag, it is possible to install the library inside a docker image (though without the plugins, of course).