### PR TITLE
Dla support

### DIFF
--- a/torch2trt/test.py
+++ b/torch2trt/test.py
@@ -101,6 +101,7 @@ if __name__ == '__main__':
     parser.add_argument('--tolerance', help='Maximum error to print warning for entry', type=float, default='-1')
     parser.add_argument('--include', help='Addition python file to include defining additional tests', action='append', default=[])
     parser.add_argument('--use_onnx', help='Whether to test using ONNX or torch2trt tracing', action='store_true')
+    parser.add_argument('--use_dla', help='Enable to use DLA during testing', action='store_true')
     args = parser.parse_args()
     
     for include in args.include:
@@ -119,6 +120,8 @@ if __name__ == '__main__':
         try:
             if args.use_onnx:
                 test.torch2trt_kwargs.update({'use_onnx': True})
+            if args.use_dla:
+                test.torch2trt_kwargs.update({'default_device_type': trt.DeviceType.DLA})
                 
             max_error, fps, fps_trt, ms, ms_trt = run(test)
 

--- a/torch2trt/test.py
+++ b/torch2trt/test.py
@@ -122,6 +122,8 @@ if __name__ == '__main__':
                 test.torch2trt_kwargs.update({'use_onnx': True})
             if args.use_dla:
                 test.torch2trt_kwargs.update({'default_device_type': trt.DeviceType.DLA})
+                if 'int8_mode' not in test.torch2trt_kwargs or test.torch2trt_kwargs['int8_mode'] == False:
+                    test.torch2trt_kwargs.update({'fp16_mode': True})  # either fp16 or int8 mode are required for DLA
                 
             max_error, fps, fps_trt, ms, ms_trt = run(test)
 

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -492,6 +492,7 @@ def torch2trt(module,
               use_onnx=False,
               default_device_type=trt.DeviceType.GPU,
               dla_core=0,
+              gpu_fallback=False,
               **kwargs):
     
     # capture arguments to provide to context
@@ -545,6 +546,11 @@ def torch2trt(module,
                 outputs = (outputs,)
             ctx.mark_outputs(outputs, output_names)
 
+    # device type
+    config.default_device_type = default_device_type
+    if gpu_fallback:
+        config.set_flag(trt.BuilderFlag.GPU_FALLBACK)
+    config.DLA_core = dla_core
     
     # workspace size
     builder.max_workspace_size = max_workspace_size

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -545,20 +545,23 @@ def torch2trt(module,
                 outputs = (outputs,)
             ctx.mark_outputs(outputs, output_names)
 
+    
     # workspace size
     builder.max_workspace_size = max_workspace_size
     config.max_workspace_size = max_workspace_size
     
     # fp16 mode
     builder.fp16_mode = fp16_mode
-    config.flags |= (1 << int(trt.BuilderFlag.FP16))
+    if fp16_mode:
+        config.set_flag(trt.BuilderFlag.FP16)
     
     # batch size
     builder.max_batch_size = max_batch_size
     
     # strict type constraints
     builder.strict_type_constraints = strict_type_constraints
-    config.flags |= (1 << int(trt.BuilderFlag.STRICT_TYPES))
+    if strict_type_constraints:
+        config.set_flag(trt.BuilderFlag.STRICT_TYPES)
 
     if int8_mode:
 
@@ -567,7 +570,7 @@ def torch2trt(module,
             int8_calib_dataset = TensorBatchDataset(inputs_in)
 
         builder.int8_mode = True
-        config.flags |= (1 << int(trt.BuilderFlag.INT8))
+        config.set_flag(trt.BuilderFlag.INT8)
 
         # @TODO(jwelsh):  Should we set batch_size=max_batch_size?  Need to investigate memory consumption
         calibrator = DatasetCalibrator(
@@ -575,7 +578,6 @@ def torch2trt(module,
         )
         builder.int8_calibrator = calibrator
         config.int8_calibrator = calibrator
-
 
     engine = builder.build_engine(network, config)
 


### PR DESCRIPTION
This PR enables DLA support through torch2trt.  Please note this is subject to change.

### Basic usage

This will enable DLA usage globally by setting the default device type.  If a particular layer is not supported by DLA, it will fall back to GPU unless ``gpu_fallback=False`` is set (it is True by default).  Please note, either ``fp16_mode=True`` or ``int8_mode=True`` are required for DLA.

```python
import torch
from torch2trt import trt, torch2trt
from torchvision.models import resnet18

model = resnet18(pretrained=True).cuda().eval()
data = torch.randn(1, 3, 224, 224).cuda()

model_trt = torch2trt(model, [data], fp16_mode=True, default_device_type=trt.DeviceType.DLA)
```

### Set device for particular modules

In some cases you may want only a particular part of the model to run on DLA.  This may be useful if your model has a large block that can run on DLA, but other parts with mixed supported / unsupported components which may occur overhead cost.  This is done at a module-level granularity.  Each lower-level set will override a higher level module, but only apply to layers added within the module.

For example, here we convert the resnet18 blocks ``layer1`` and ``layer2`` and the first block in ``layer3`` to run on DLA.  

```python
model_trt = torch2trt(model, [data], default_device_type=trt.DeviceType.GPU, fp16_mode=True, device_types={
    model.layer1: trt.DeviceType.DLA, 
    model.layer2: trt.DeviceType.DLA, 
    model.layer3[0]: trt.DeviceType.DLA
})
```

You could do the inverse of this if you wanted.

```python
model_trt = torch2trt(model, [data], default_device_type=trt.DeviceType.DLA, fp16_mode=True, device_types={
    model.layer1: trt.DeviceType.GPU, 
    model.layer2: trt.DeviceType.GPU, 
    model.layer3[0]: trt.DeviceType.GPU
})
```

In any instance, a DLA layer will run on GPU if ``gpu_fallback=True``.  If you would prefer to disable this behavior, you can set ``gpu_fallback=False``, but TensorRT optimization may fail internally.  

TODO

- validate existing test cases.  may be cool to log DLA supported layers https://nvidia-ai-iot.github.io/torch2trt/master/converters.html
- perform sanity checks on real world model / data