### PR TITLE
avg_pool line-71 stride variable is return None.

### DIFF
--- a/torch2trt/converters/avg_pool.py
+++ b/torch2trt/converters/avg_pool.py
@@ -65,6 +65,8 @@ def convert_avg_pool_trt7(ctx):
         kernel_size = (kernel_size, ) * input_dim
 
     # get stride
+    if stride is None:
+        stride = kernel
     if not isinstance(stride, tuple):
         stride = (stride, ) * input_dim
 


### PR DESCRIPTION
if you are using avg_pool, stride variable is return None and converting error return you can use stride=kernel_size 