### PR TITLE
support torch2trt() conversion for TensorRt 8.0;

### DIFF
--- a/torch2trt/converters/interpolate.py
+++ b/torch2trt/converters/interpolate.py
@@ -90,6 +90,47 @@ def convert_interpolate_trt7(ctx):
 
     output._trt = layer.get_output(0)
 
+@tensorrt_converter('torch.nn.functional.interpolate', enabled=trt_version() >= '8.0')
+@tensorrt_converter('torch.nn.functional.upsample', enabled=trt_version() >= '8.0')
+def convert_interpolate_trt8(ctx):                                     
+    #parse args                     
+    input = get_arg(ctx, 'input', pos=0, default=None) 
+    size = get_arg(ctx, 'size', pos=1, default=None)
+    scale_factor=get_arg(ctx, 'scale_factor', pos=2, default=None)
+    mode = get_arg(ctx, 'mode', pos=3, default='nearest')
+    align_corners = get_arg(ctx, 'align_corners', pos=4, default=None)
+
+    input_dim = input.dim() - 2
+    
+    input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
+    output = ctx.method_return
+    layer = ctx.network.add_resize(input=input_trt)
+
+    shape = size
+    if shape != None:
+        if isinstance(shape, collections.Sequence):
+           shape  = [input.size(1)] + list(shape)
+        else:
+            shape = [input.size(1)] + [shape] * input_dim
+
+        layer.shape = shape
+
+    scales = scale_factor
+    if scales != None:
+        if not isinstance(scales, collections.Sequence):
+            scales = [scales] * input_dim
+        layer.scales = [1] + list(scales)
+
+    resize_mode = mode
+    if resize_mode.lower() in ["linear","bilinear","trilinear"]:
+        layer.resize_mode = trt.ResizeMode.LINEAR
+    else:
+        layer.resize_mode=trt.ResizeMode.NEAREST
+
+    if align_corners:
+        layer.coordinate_transformation = trt.ResizeCoordinateTransformation.ALIGN_CORNERS
+
+    output._trt = layer.get_output(0)
 
 class Interpolate(torch.nn.Module):
     def __init__(self, size, mode, align_corners):

--- a/torch2trt/converters/mod.py
+++ b/torch2trt/converters/mod.py
@@ -64,7 +64,7 @@ class ModAssign(torch.nn.Module):
         super(ModAssign, self).__init__()
 
     def forward(self, x, y):
-        x %= y
+        x = x % y
         return x
 
 

--- a/torch2trt/test.py
+++ b/torch2trt/test.py
@@ -108,7 +108,6 @@ if __name__ == '__main__':
         
     num_tests, num_success, num_tolerance, num_error = 0, 0, 0, 0
     for test in MODULE_TESTS:
-        
         # filter by module name
         name = test.module_name()
         if not re.search(args.name, name):

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -556,10 +556,10 @@ def torch2trt(module,
                 outputs = (outputs,)
             ctx.mark_outputs(outputs, output_names)
 
-    builder.max_workspace_size = max_workspace_size
-    builder.fp16_mode = fp16_mode
+    config = builder.create_builder_config()
+    config.max_workspace_size = max_workspace_size
+    config.flags = fp16_mode << int(trt.BuilderFlag.FP16) | strict_type_constraints << int(trt.BuilderFlag.STRICT_TYPES)
     builder.max_batch_size = max_batch_size
-    builder.strict_type_constraints = strict_type_constraints
 
     if int8_mode:
 
@@ -574,7 +574,7 @@ def torch2trt(module,
             inputs, int8_calib_dataset, batch_size=int8_calib_batch_size, algorithm=int8_calib_algorithm
         )
 
-    engine = builder.build_cuda_engine(network)
+    engine = builder.build_engine(network, config)
 
     module_trt = TRTModule(engine, input_names, output_names)
 


### PR DESCRIPTION
- support torch2trt() conversion for TensorRT 8.0;
- fix unit tests for TensorRT 8.0;
- fixed `Warning: Encountered known unsupported method torch.Tensor.__imod__` when using imod [ `x %= y` ];
- fix tensorrt 8.0 api incompatibility in `convert_interpolate_trt8()` for choosing resize type `trt.ResizeCoordinateTransformation.ALIGN_CORNERS`.

### Unit tests output
```
NUM_TESTS: 313
NUM_SUCCESSFUL_CONVERSION: 313
NUM_FAILED_CONVERSION: 0
NUM_ABOVE_TOLERANCE: 1
```

### System info
PyTorch `1.9.0+cu111`
Cuda `11.1`
TensorRT `8.0.0.3`
Platform `Ubuntu 18.04.1` kernel `5.4.0-77-generic`
GPU `RTX 3090`  