### PR TITLE
Test enhancement and doc correction for QAT

### DIFF
--- a/examples/contrib/quantization_aware_training/README.md
+++ b/examples/contrib/quantization_aware_training/README.md
@@ -25,27 +25,9 @@ RUN add-apt-repository ppa:git-core/ppa && \
 
 RUN pip install termcolor graphviz
 
-## If you have followed instructions on main README.md file to install torch2trt using scripts/build_contrib.sh
-## You dont require rest of the steps
-
-RUN git clone https://github.com/NVIDIA/TensorRT.git /sw/TensorRT/
-
-##Make sure that patch file is under the same folder where dockerfile is being called
-
-ADD pytorch_nvidia_quantization.patch /sw/TensorRT
-
-RUN cd /sw/TensorRT/ && \
-    git sparse-checkout init --cone && \
-    git sparse-checkout set /tools/pytorch-quantization/ && \
-    git apply --reject --whitespace=fix pytorch_nvidia_quantization.patch && \
-    cd tools/pytorch-quantization/ && \
-    python setup.py install 
-
-RUN git clone https://github.com/NVIDIA-AI-IOT/torch2trt.git /sw/TensorRT/ && \
-    cd /sw/TensorRT/ && \
-    git fetch origin pull/514/head:PR514 && \
-    git checkout PR514 && \
-    python setup.py install --plugins
+RUN git clone https://github.com/NVIDIA-AI-IOT/torch2trt.git /sw/torch2trt/ && \
+    cd /sw/torch2trt/scripts && \
+	bash build_contrib.sh
 
 ```
 

--- a/torch2trt/converters/interpolate.py
+++ b/torch2trt/converters/interpolate.py
@@ -92,34 +92,36 @@ def convert_interpolate_trt7(ctx):
 
 
 class Interpolate(torch.nn.Module):
-    def __init__(self, size, mode, align_corners):
+    def __init__(self, size=None,scale_factor=None, mode=None, align_corners=None):
         super(Interpolate, self).__init__()
+		## Use either size or scale factor. 
         self.size = size
+        self.scale_factor = scale_factor 
         self.mode = mode
         self.align_corners = align_corners
 
     def forward(self, x):
-        return F.interpolate(x, self.size, mode=self.mode, align_corners=self.align_corners)
+        return F.interpolate(x, size=self.size, scale_factor=self.scale_factor,mode=self.mode, align_corners=self.align_corners)
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 10, 112, 112)], enabled=trt_version() < '7.1' and has_interpolate_plugin())
 def test_interpolate_nearest():
-    return Interpolate((224, 224), 'nearest', None)
+    return Interpolate(size=(224, 224), mode='nearest', align_corners=None)
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 10, 112, 112)], enabled=trt_version() < '7.1' and has_interpolate_plugin())
 def test_interpolate_bilinear():
-    return Interpolate((224, 224), 'bilinear', False)
+    return Interpolate(size=(224, 224), mode= 'bilinear', align_corners=False)
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 10, 112, 112)], enabled=trt_version() < '7.1' and has_interpolate_plugin())
 def test_interpolate_bicubic():
-    return Interpolate((224, 224), 'bicubic', False)
+    return Interpolate(size=(224, 224), mode='bicubic',align_corners= False)
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 10, 112, 112)], enabled=trt_version() < '7.1' and has_interpolate_plugin())
 def test_interpolate_area():
-    return Interpolate((56, 56), 'area', None)
+    return Interpolate(size=(56, 56), mode='area',align_corners= None)
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 10, 112, 112)], enabled=trt_version() < '7.1' and has_interpolate_plugin())
 def test_upsample_scale_factor2():
@@ -135,7 +137,11 @@ def test_bilinear_mode():
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1,3,12,12)], enabled=trt_version() >= '7.1')
 def test_align_corner():
-    return torch.nn.Upsample(scale_factor=2, mode="bilinear", align_corners=True)
+    return torch.nn.Upsample(scale_factor=2.0, mode="bilinear", align_corners=True)
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1,3,12,12)], enabled=trt_version() >= '7.1')
+def test_align_corner_functional():
+    return Interpolate(scale_factor=2.0, mode="bilinear", align_corners=True)
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1,5,13,13)], enabled=trt_version() >= '7.1')
 def test_bilinear_mode_odd_input_shape():

--- a/torch2trt/test.py
+++ b/torch2trt/test.py
@@ -140,7 +140,7 @@ if __name__ == '__main__':
     for include in args.include:
         runpy.run_module(include)
         
-    num_tests, num_success, num_tolerance, num_error = 0, 0, 0, 0
+    num_tests, num_success, num_tolerance, num_error, num_tolerance_psnr = 0, 0, 0, 0, 0
     for test in MODULE_TESTS:
         
         # filter by module name
@@ -162,6 +162,9 @@ if __name__ == '__main__':
             if args.tolerance >= 0 and max_error > args.tolerance:
                 print(colored(line, 'yellow'))
                 num_tolerance += 1
+            elif psnr_db < 100:
+                print(colored(line, 'magenta'))
+                num_tolerance_psnr +=1
             else:
                 print(line)
             num_success += 1
@@ -179,3 +182,4 @@ if __name__ == '__main__':
     print('NUM_SUCCESSFUL_CONVERSION: %d' % num_success)
     print('NUM_FAILED_CONVERSION: %d' % num_error)
     print('NUM_ABOVE_TOLERANCE: %d' % num_tolerance)
+    print('NUM_pSNR_TOLERANCE: %d' %num_tolerance_psnr)

--- a/torch2trt/test.py
+++ b/torch2trt/test.py
@@ -157,7 +157,7 @@ if __name__ == '__main__':
             max_error,psnr_db,mse, fps, fps_trt, ms, ms_trt = run(test)
 
             # write entry
-            line = '| %s | %s | %s | %s | %.2E | %.4f | %.4f | %.3g | %.3g | %.3g | %.3g |' % (name, test.dtype.__repr__().split('.')[-1], str(test.input_shapes), str(test.torch2trt_kwargs), max_error,psnr_db,mse, fps, fps_trt, ms, ms_trt)
+            line = '| %70s | %s | %25s | %s | %.2E | %.4f | %.4f | %.3g | %.3g | %.3g | %.3g |' % (name, test.dtype.__repr__().split('.')[-1], str(test.input_shapes), str(test.torch2trt_kwargs), max_error,psnr_db,mse, fps, fps_trt, ms, ms_trt)
         
             if args.tolerance >= 0 and max_error > args.tolerance:
                 print(colored(line, 'yellow'))

--- a/torch2trt/test.py
+++ b/torch2trt/test.py
@@ -157,7 +157,7 @@ if __name__ == '__main__':
             max_error,psnr_db,mse, fps, fps_trt, ms, ms_trt = run(test)
 
             # write entry
-            line = '| %70s | %s | %25s | %s | %.2E | %.4f | %.4f | %.3g | %.3g | %.3g | %.3g |' % (name, test.dtype.__repr__().split('.')[-1], str(test.input_shapes), str(test.torch2trt_kwargs), max_error,psnr_db,mse, fps, fps_trt, ms, ms_trt)
+            line = '| %70s | %s | %25s | %s | %.2E | %.2f | %.2E | %.3g | %.3g | %.3g | %.3g |' % (name, test.dtype.__repr__().split('.')[-1], str(test.input_shapes), str(test.torch2trt_kwargs), max_error,psnr_db,mse, fps, fps_trt, ms, ms_trt)
         
             if args.tolerance >= 0 and max_error > args.tolerance:
                 print(colored(line, 'yellow'))


### PR DESCRIPTION
Hi @jaybdub: 

Hope you are doing well. This PR 

1. fixes documentation for QAT section
2. makes the output much more readable for test.py
3. **Added pSNR (peak signal to noise ratio test) for all the converters.** 

I have been using pSNR test for quite sometime to test the correctness of TRT conversion instead of max difference as pSNR is more robust test than max difference. 

There is an issue with interpolate layer in TRT>=7 when `align_corners=True`. I added a unit test for a similar set of parameters where internal model metrics were showing regression. However, the unit test passed the `max_difference` test in the repo but failed on `pSNR` test. **_I will get back to this test case at the end_** 

Usually, when we calculate pSNR at FP32 , if `pSNR>=100` , it is safe to say that the conversion was fine. The best case is when `pSNR=NaN` , i.e. , `MSE` or `mean squared error` was zero , that led to pSNR being an infinite number which means that both the output tensors (pytorch model output and trt model output) were identical 

Although I havent added pSNR test at FP16 in the repo, I can summarize my findings here , so that if you feel free, we can add those later on. 

Inspired from Image processing basics, if 
1. `pSNR at FP32 >= 100db` , we can safely say that the conversion is good
2. `pSNR at FP16 ~= (pSNR at FP32)//2 - x`

`x~=10`. Based on numerous experiments that I did, `x` is around `10db` and accounts for variance. 

```
There is no mathematical explanation but a toolchain explanation.
TRT basically fuses layers , uses different kernels to execute same layers after fusion, so these optimizations introduce some kind of bias (as one would call). However, if you look at the model as a whole, net effect is 0.
Since we are comparing an unoptimized network with an optimized one, value by value , we can see that difference during pSNR test. However, it will not show up when we run a PR.
```

For e.g.

```
pSNR at FP32 = 120db
pSNR at FP16 = 120/2-10 = 50db

For FP32, if pSNR is less than 100db (regardless of the above example) , then there is a conversion issue. 
For FP16, if pSNR is less than 50db (in the above example), then there is a conversion issue
```

`pSNR will drop if MSE (mean squared error) is high`

Now back to interpolate conversion issue

```
|                    torch2trt.converters.interpolate.test_bilinear_mode | float32 |          [(1, 4, 12, 12)] | {} | 2.38E-07 | 160.7023 | 0.0000 | 4.08e+04 | 1.58e+04 | 0.0425 | 0.0799 |
|                     torch2trt.converters.interpolate.test_align_corner | float32 |          [(1, 3, 12, 12)] | {} | 1.90E+00 | 14.5676 | 0.2077 | 4.21e+04 | 1.58e+04 | 0.0423 | 0.0792 |
|          torch2trt.converters.interpolate.test_align_corner_functional | float32 |          [(1, 3, 12, 12)] | {} | 2.01E+00 | 16.1512 | 0.1890 | 4.09e+04 | 1.54e+04 | 0.0433 | 0.0819 |
|    torch2trt.converters.interpolate.test_bilinear_mode_odd_input_shape | float32 |          [(1, 5, 13, 13)] | {} | 2.38E-07 | 155.6233 | 0.0000 | 4.2e+04 | 1.59e+04 | 0.0419 | 0.0798 |
```

As you can see all the 4 tests pass `max difference` test. However, the middle tests represent test cases where `align_corner=True` and `pSNR <20db at FP32` which indicates that there is a problem in conversion and it leads to degradation in model metrics. `1st and 4th` tests have `align_corner=False` and pSNR is way greater than 100. 

I have already raised the issue with Nvidia and it is being looked into. I think pSNR test will make our unit tests more robust and we should definitely add them 

Let me know if you have any questions

Thanks 

Kshitij Srivastava
