### PR TITLE
Added TensorRT Converters for Basic Casting Operations

### DIFF
--- a/torch2trt/converters/__init__.py
+++ b/torch2trt/converters/__init__.py
@@ -67,3 +67,4 @@ from .tensor import *
 from .transpose import *
 from .unary import *
 from .view import *
+from .cast import *

--- a/torch2trt/converters/cast.py
+++ b/torch2trt/converters/cast.py
@@ -32,6 +32,8 @@ def convert_bool(ctx):
 def convert_bool(ctx):
     convert_cast(ctx)
 
+# Used for torch.Tensor.<cast> tests
+# --------------------------------------------
 
 class TorchFloat(torch.nn.Module):
     def __init__(self):
@@ -59,17 +61,62 @@ class TorchBool(torch.nn.Module):
 
 @add_module_test(torch.bool, torch.device('cuda'), [(1, 3, 3)])
 @add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
-def test_float_casting():
+def test_torch_float_cast():
     return TorchFloat()
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
 @add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
-def test_int_casting():
+def test_torch_int_cast():
     return TorchInt()
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
 @add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
-def test_bool_casting():
+def test_torch_bool_casting():
     return TorchBool()
+
+
+# Used for torch.<cast> tests
+# --------------------------------------------
+
+class DotFloat(torch.nn.Module):
+    def __init__(self):
+        super(DotFloat, self).__init__()
+
+    def forward(self, x):
+        return x.float()
+
+
+class DotInt(torch.nn.Module):
+    def __init__(self):
+        super(DotInt, self).__init__()
+
+    def forward(self, x):
+        return x.int()
+
+
+class DotBool(torch.nn.Module):
+    def __init__(self):
+        super(DotBool, self).__init__()
+
+    def forward(self, x):
+        return x.bool()
+
+
+@add_module_test(torch.bool, torch.device('cuda'), [(1, 3, 3)])
+@add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
+def test_float_cast():
+    return DotFloat()
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
+@add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
+def test_int_cast():
+    return DotInt()
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
+@add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
+def test_bool_cast():
+    return DotBool()

--- a/torch2trt/converters/cast.py
+++ b/torch2trt/converters/cast.py
@@ -15,22 +15,20 @@ def convert_cast(ctx):
     output._trt = layer.get_output(0)
 
 
-@tensorrt_converter("torch.float")
 @tensorrt_converter("torch.Tensor.float")
 def convert_float(ctx):
     convert_cast(ctx)
 
 
-@tensorrt_converter("torch.bool")
 @tensorrt_converter("torch.Tensor.bool")
 def convert_bool(ctx):
     convert_cast(ctx)
 
 
-@tensorrt_converter("torch.float")
 @tensorrt_converter("torch.Tensor.float")
 def convert_bool(ctx):
     convert_cast(ctx)
+
 
 # Used for torch.Tensor.<cast> tests
 # --------------------------------------------
@@ -75,48 +73,3 @@ def test_torch_int_cast():
 @add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
 def test_torch_bool_casting():
     return TorchBool()
-
-
-# Used for torch.<cast> tests
-# --------------------------------------------
-
-class DotFloat(torch.nn.Module):
-    def __init__(self):
-        super(DotFloat, self).__init__()
-
-    def forward(self, x):
-        return x.float()
-
-
-class DotInt(torch.nn.Module):
-    def __init__(self):
-        super(DotInt, self).__init__()
-
-    def forward(self, x):
-        return x.int()
-
-
-class DotBool(torch.nn.Module):
-    def __init__(self):
-        super(DotBool, self).__init__()
-
-    def forward(self, x):
-        return x.bool()
-
-
-@add_module_test(torch.bool, torch.device('cuda'), [(1, 3, 3)])
-@add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
-def test_float_cast():
-    return DotFloat()
-
-
-@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
-@add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
-def test_int_cast():
-    return DotInt()
-
-
-@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
-@add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
-def test_bool_cast():
-    return DotBool()

--- a/torch2trt/converters/cast.py
+++ b/torch2trt/converters/cast.py
@@ -20,12 +20,12 @@ def convert_float(ctx):
     convert_cast(ctx)
 
 
-@tensorrt_converter("torch.Tensor.bool")
-def convert_bool(ctx):
+@tensorrt_converter("torch.Tensor.int")
+def convert_int(ctx):
     convert_cast(ctx)
 
 
-@tensorrt_converter("torch.Tensor.float")
+@tensorrt_converter("torch.Tensor.bool")
 def convert_bool(ctx):
     convert_cast(ctx)
 

--- a/torch2trt/converters/cast.py
+++ b/torch2trt/converters/cast.py
@@ -7,7 +7,7 @@ def convert_cast(ctx):
     A simple converter for supporting casting operations.
 
     IMPORTANT: Note that because TensorRT does not support
-    64 bit data types, .long() will not be supported
+    64 bit data types, .long() is not included.
     """
     input_tensor = ctx.method_args[0]
     layer = ctx.network.add_identity(input_tensor._trt)
@@ -31,3 +31,45 @@ def convert_bool(ctx):
 @tensorrt_converter("torch.Tensor.float")
 def convert_bool(ctx):
     convert_cast(ctx)
+
+
+class ConvertToFloat(torch.nn.Module):
+    def __init__(self):
+        super(ConvertToFloat, self).__init__()
+
+    def forward(self, x):
+        return x.float()
+
+
+class ConvertToInt(torch.nn.Module):
+    def __init__(self):
+        super(ConvertToInt, self).__init__()
+
+    def forward(self, x):
+        return x.int()
+
+
+class ConvertToBool(torch.nn.Module):
+    def __init__(self):
+        super(ConvertToBool, self).__init__()
+
+    def forward(self, x):
+        return x.bool()
+
+
+@add_module_test(torch.bool, torch.device('cuda'), [(1, 3, 3)])
+@add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
+def test_float_casting():
+    return ConvertToFloat()
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
+@add_module_test(torch.bool, torch.device('cuda'), [(1, 3, 3)])
+def test_int_casting():
+    return ConvertToInt()
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
+@add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
+def test_bool_casting():
+    return ConvertToBool()

--- a/torch2trt/converters/cast.py
+++ b/torch2trt/converters/cast.py
@@ -30,9 +30,6 @@ def convert_bool(ctx):
     convert_cast(ctx)
 
 
-# Used for torch.Tensor.<cast> tests
-# --------------------------------------------
-
 class DotFloat(torch.nn.Module):
     def __init__(self):
         super(DotFloat, self).__init__()

--- a/torch2trt/converters/cast.py
+++ b/torch2trt/converters/cast.py
@@ -33,43 +33,43 @@ def convert_bool(ctx):
 # Used for torch.Tensor.<cast> tests
 # --------------------------------------------
 
-class TorchFloat(torch.nn.Module):
+class DotFloat(torch.nn.Module):
     def __init__(self):
-        super(TorchFloat, self).__init__()
+        super(DotFloat, self).__init__()
 
     def forward(self, x):
-        return torch.float(x)
+        return x.float()
 
 
-class TorchInt(torch.nn.Module):
+class DotInt(torch.nn.Module):
     def __init__(self):
-        super(TorchInt, self).__init__()
+        super(DotInt, self).__init__()
 
     def forward(self, x):
-        return torch.int(x)
+        return x.int()
 
 
-class TorchBool(torch.nn.Module):
+class DotBool(torch.nn.Module):
     def __init__(self):
-        super(TorchBool, self).__init__()
+        super(DotBool, self).__init__()
 
     def forward(self, x):
-        return torch.bool(x)
+        return x.bool()
 
 
 @add_module_test(torch.bool, torch.device('cuda'), [(1, 3, 3)])
 @add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
 def test_torch_float_cast():
-    return TorchFloat()
+    return DotFloat()
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
 @add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
 def test_torch_int_cast():
-    return TorchInt()
+    return DotInt()
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
 @add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
 def test_torch_bool_casting():
-    return TorchBool()
+    return DotBool()

--- a/torch2trt/converters/cast.py
+++ b/torch2trt/converters/cast.py
@@ -71,5 +71,5 @@ def test_torch_int_cast():
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
 @add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
-def test_torch_bool_casting():
+def test_torch_bool_cast():
     return DotBool()

--- a/torch2trt/converters/cast.py
+++ b/torch2trt/converters/cast.py
@@ -1,0 +1,33 @@
+from torch2trt.torch2trt import *
+from torch2trt.module_test import add_module_test
+
+
+def convert_cast(ctx):
+    """
+    A simple converter for supporting casting operations.
+
+    IMPORTANT: Note that because TensorRT does not support
+    64 bit data types, .long() will not be supported
+    """
+    input_tensor = ctx.method_args[0]
+    layer = ctx.network.add_identity(input_tensor._trt)
+    output = ctx.method_return
+    output._trt = layer.get_output(0)
+
+
+@tensorrt_converter("torch.float")
+@tensorrt_converter("torch.Tensor.float")
+def convert_float(ctx):
+    convert_cast(ctx)
+
+
+@tensorrt_converter("torch.bool")
+@tensorrt_converter("torch.Tensor.bool")
+def convert_bool(ctx):
+    convert_cast(ctx)
+
+
+@tensorrt_converter("torch.float")
+@tensorrt_converter("torch.Tensor.float")
+def convert_bool(ctx):
+    convert_cast(ctx)

--- a/torch2trt/converters/cast.py
+++ b/torch2trt/converters/cast.py
@@ -7,7 +7,7 @@ def convert_cast(ctx):
     A simple converter for supporting casting operations.
 
     IMPORTANT: Note that because TensorRT does not support
-    64 bit data types, .long() is not included.
+    64 bit data types, .long() will not be supported
     """
     input_tensor = ctx.method_args[0]
     layer = ctx.network.add_identity(input_tensor._trt)
@@ -33,43 +33,43 @@ def convert_bool(ctx):
     convert_cast(ctx)
 
 
-class ConvertToFloat(torch.nn.Module):
+class TorchFloat(torch.nn.Module):
     def __init__(self):
-        super(ConvertToFloat, self).__init__()
+        super(TorchFloat, self).__init__()
 
     def forward(self, x):
-        return x.float()
+        return torch.float(x)
 
 
-class ConvertToInt(torch.nn.Module):
+class TorchInt(torch.nn.Module):
     def __init__(self):
-        super(ConvertToInt, self).__init__()
+        super(TorchInt, self).__init__()
 
     def forward(self, x):
-        return x.int()
+        return torch.int(x)
 
 
-class ConvertToBool(torch.nn.Module):
+class TorchBool(torch.nn.Module):
     def __init__(self):
-        super(ConvertToBool, self).__init__()
+        super(TorchBool, self).__init__()
 
     def forward(self, x):
-        return x.bool()
+        return torch.bool(x)
 
 
 @add_module_test(torch.bool, torch.device('cuda'), [(1, 3, 3)])
 @add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
 def test_float_casting():
-    return ConvertToFloat()
+    return TorchFloat()
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
-@add_module_test(torch.bool, torch.device('cuda'), [(1, 3, 3)])
+@add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
 def test_int_casting():
-    return ConvertToInt()
+    return TorchInt()
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
 @add_module_test(torch.int32, torch.device('cuda'), [(1, 3, 3)])
 def test_bool_casting():
-    return ConvertToBool()
+    return TorchBool()


### PR DESCRIPTION
Added support for the following casting operations under the `converters/cast.py`.
- `.float()`. e.g `x.float()`
- `.int()`. e.g `x.int()`
- `.bool()`. e.g `x.bool()`

Tests are included along with the converters (see attached image below).

**Note**: `.long()` is not included as this is a 64 bit data type and TensorRT does not support 64 bit data types. 

![cast_test](https://user-images.githubusercontent.com/26952818/129014207-bb1d0d60-b5a8-4886-8823-8d5db0503d6f.png)
