### PR TITLE
add converter for torch.Tensor.expand_as() method

### DIFF
--- a/torch2trt/converters/__init__.py
+++ b/torch2trt/converters/__init__.py
@@ -29,6 +29,7 @@ from .clamp import *
 from .compare import *
 from .div import *
 from .expand import *
+from .expand_as import *
 from .floordiv import *
 from .gelu import *
 from .getitem import *

--- a/torch2trt/converters/expand_as.py
+++ b/torch2trt/converters/expand_as.py
@@ -1,0 +1,52 @@
+from torch2trt.torch2trt import *
+from torch2trt.module_test import add_module_test
+
+
+@tensorrt_converter('torch.Tensor.expand_as')
+def convert_expand_as(ctx):
+    input = ctx.method_args[0]
+    output = ctx.method_return
+    
+    inshape = tuple(input.shape)[1:] # exclude batch
+    shape = tuple(output.shape)[1:]
+    ndim = len(shape)
+    start = tuple([0]*ndim)
+    stride = tuple([int(i == o) for i, o in zip(inshape, shape)])  # stride == 1 if dimensions match, 0 otherwise
+    
+    layer = ctx.network.add_slice(input._trt, start, shape, stride)
+    
+    output._trt = layer.get_output(0)
+    
+    
+class ExpandAsModule(torch.nn.Module):
+    def __init__(self, other: torch.Tensor):
+        super(ExpandAsModule, self).__init__()
+        self.other = other
+    
+    def forward(self, x: torch.Tensor):
+        return x.expand_as(self.other)
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1),])
+def test_tensor_expand_as_scalar():
+    return ExpandAsModule(torch.randn(3))
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 1, 3, 3),])
+def test_tensor_expand_as_singledim():
+    return ExpandAsModule(torch.randn((1, 3, 3, 3)))
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 1, 1, 3),])
+def test_tensor_expand_as_multidim():
+    return ExpandAsModule(torch.randn((1, 3, 3, 3)))
+
+
+@add_module_test(torch.float16, torch.device('cuda'), [(1, 1, 3, 3),])
+def test_tensor_expand_as_singledim_half():
+    return ExpandAsModule(torch.randn((1, 3, 3, 3)))
+
+
+@add_module_test(torch.float16, torch.device('cuda'), [(1, 1, 1, 3),])
+def test_tensor_expand_as_multidim_half():
+    return ExpandAsModule(torch.randn((1, 3, 3, 3)))


### PR DESCRIPTION
## Description
This PR is related to Issue #565,  but **it cannot be closed yet** even when this PR is merged.

A converter for `torch.Tensor.expand(size)` already exists, but `torch.Tensor.expand_as(other)` did not.
Users can convert `expand_as` by replacing all `expand_as(other)` into `expand(other.size())`, but it should not be a favorable way.

I made a converter `torch2trt/converters/expand_as.py` similar to `torch2trt/converters/expand.py`, with some new test cases.

The result of testing in my environment is as follows:

## Environment
Ubuntu 20.04
Python 3.8.8
torch 1.8.1
torch2trt 0.2.0
cuda 11.1
cudnn 8.1.1
TensorRT 7.2.2

## Test Result

|            torch2trt.converters.expand_as.test_tensor_expand_as_scalar | float32 |                       [1] | {} | 0.00E+00 | nan | 0.00E+00 | 3.4e+05 | 1.88e+04 | 0.014 | 0.0646 |
|         torch2trt.converters.expand_as.test_tensor_expand_as_singledim | float32 |            [(1, 1, 3, 3)] | {} | 0.00E+00 | nan | 0.00E+00 | 3.3e+05 | 1.97e+04 | 0.0129 | 0.0631 |
|          torch2trt.converters.expand_as.test_tensor_expand_as_multidim | float32 |            [(1, 1, 1, 3)] | {} | 0.00E+00 | nan | 0.00E+00 | 3.2e+05 | 1.78e+04 | 0.0138 | 0.0635 |
|    torch2trt.converters.expand_as.test_tensor_expand_as_singledim_half | float16 |            [(1, 1, 3, 3)] | {} | 0.00E+00 | nan | 0.00E+00 | 3.17e+05 | 1.52e+04 | 0.0167 | 0.0877 |
|     torch2trt.converters.expand_as.test_tensor_expand_as_multidim_half | float16 |            [(1, 1, 1, 3)] | {} | 0.00E+00 | nan | 0.00E+00 | 3.25e+05 | 1.53e+04 | 0.0134 | 0.0784 |
NUM_TESTS: 5
NUM_SUCCESSFUL_CONVERSION: 5
NUM_FAILED_CONVERSION: 0
NUM_ABOVE_TOLERANCE: 0
NUM_pSNR_TOLERANCE: 0
