### PR TITLE
[WIP] Update plugin classes to match the base IPluginV2 class in TensorRT8

### DIFF
--- a/torch2trt/plugins/group_norm.cpp
+++ b/torch2trt/plugins/group_norm.cpp
@@ -112,19 +112,19 @@ public:
         return data_str.str();
     }
     
-    const char* getPluginType() const override {
+    const char* getPluginType() const noexcept override {
       return "group_norm";
     };
 
-    const char* getPluginVersion() const override {
+    const char* getPluginVersion() const noexcept override {
       return "1";
     }
 
-    int getNbOutputs() const override {
+    int getNbOutputs() const noexcept override {
       return 1;
     } 
 
-    Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
+    Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) noexcept override {
       Dims dims;
       dims.nbDims = inputs->nbDims;
   
@@ -135,8 +135,8 @@ public:
       return dims;
     }
 
-    bool supportsFormat(DataType type, PluginFormat format) const override {
-      if (format != PluginFormat::kNCHW) {
+    bool supportsFormat(DataType type, PluginFormat format) const noexcept override {
+      if (format != PluginFormat::kLINEAR) {
         return false;
       }
       if (type == DataType::kINT32 || type == DataType::kINT8) {
@@ -146,7 +146,7 @@ public:
     }
 
   void configureWithFormat(const Dims* inputDims, int nbInputs, const Dims* outputDims,
-      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) override {
+      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) noexcept override {
     
     // set data type
     if (type == DataType::kFLOAT) {
@@ -170,7 +170,7 @@ public:
     }
   }
 
-  int initialize() override {
+  int initialize() noexcept override {
     // set device
     tensor_options = tensor_options.device(c10::kCUDA);
       
@@ -188,11 +188,12 @@ public:
     return 0;
   }
 
-  void terminate() override {}
+  void terminate() noexcept override {}
 
-  size_t getWorkspaceSize(int maxBatchSize) const override { return 0; }
+  size_t getWorkspaceSize(int maxBatchSize) const noexcept override { return 0; }
 
-  int enqueue(int batchSize, const void* const* inputs, void** outputs, void* workspace, cudaStream_t stream) override {
+  int32_t enqueue(int32_t batchSize, void const* const* inputs, void* const* outputs, void* workspace,
+        cudaStream_t stream) noexcept override {
     // get input / output dimensions
     std::vector<long> batch_input_sizes = input_sizes;
     std::vector<long> batch_output_sizes = output_sizes;
@@ -235,25 +236,25 @@ public:
   }
 
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const noexcept override {
     return serializeToString().size();
   }
     
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const noexcept override {
       std::string data = serializeToString();
       size_t size = getSerializationSize();
       data.copy((char *) buffer, size);
   }
 
-  void destroy() override {}
+  void destroy() noexcept override {}
 
-  IPluginV2* clone() const override {
+  IPluginV2* clone() const noexcept override {
     return new GroupNormPlugin(num_groups, weight, bias, eps); 
   }
 
-  void setPluginNamespace(const char* pluginNamespace) override {}
+  void setPluginNamespace(const char* pluginNamespace) noexcept override {}
 
-  const char *getPluginNamespace() const override {
+  const char *getPluginNamespace() const noexcept override {
     return "torch2trt";
   }
 
@@ -263,26 +264,26 @@ class GroupNormPluginCreator : public IPluginCreator {
 public:
   GroupNormPluginCreator() {}
 
-  const char *getPluginNamespace() const override {
+  const char *getPluginNamespace() const noexcept override {
     return "torch2trt";
   }
 
-  const char *getPluginName() const override {
+  const char *getPluginName() const noexcept override {
     return "group_norm";
   }
 
-  const char *getPluginVersion() const override {
+  const char *getPluginVersion() const noexcept override {
     return "1";
   }
 
-  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) override {
+  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) noexcept override {
     return new GroupNormPlugin((const char*) data, length);
   }
 
-  void setPluginNamespace(const char *N) override {}
-  const PluginFieldCollection *getFieldNames() override { return nullptr; }
+  void setPluginNamespace(const char *N) noexcept override {}
+  const PluginFieldCollection *getFieldNames() noexcept override { return nullptr; }
 
-  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) override { return nullptr; }
+  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) noexcept override { return nullptr; }
 
 };
 

--- a/torch2trt/plugins/interpolate.cpp
+++ b/torch2trt/plugins/interpolate.cpp
@@ -103,19 +103,19 @@ public:
       return data_str.str();
   }
 
-  const char* getPluginType() const override {
+  const char* getPluginType() const noexcept override {
     return "interpolate";
   };
 
-  const char* getPluginVersion() const override {
+  const char* getPluginVersion() const noexcept override {
     return "1";
   }
 
-  int getNbOutputs() const override {
+  int getNbOutputs() const noexcept override {
     return 1;
   } 
 
-  Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
+  Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) noexcept override {
     Dims dims;
     dims.nbDims = inputs->nbDims;
 
@@ -127,8 +127,8 @@ public:
     return dims;
   }
 
-  bool supportsFormat(DataType type, PluginFormat format) const override {
-    if (format != PluginFormat::kNCHW) {
+  bool supportsFormat(DataType type, PluginFormat format) const noexcept override {
+    if (format != PluginFormat::kLINEAR) {
       return false;
     }
     if (type == DataType::kINT32 || type == DataType::kINT8) {
@@ -138,7 +138,7 @@ public:
   }
 
   void configureWithFormat(const Dims* inputDims, int nbInputs, const Dims* outputDims,
-      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) override {
+      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) noexcept override {
     
     // set data type
     if (type == DataType::kFLOAT) {
@@ -162,7 +162,7 @@ public:
     }
   }
 
-  int initialize() override {
+  int initialize() noexcept override {
     // set device
     tensor_options = tensor_options.device(c10::kCUDA);
       
@@ -176,11 +176,12 @@ public:
     return 0;
   }
 
-  void terminate() override {}
+  void terminate() noexcept override {}
 
-  size_t getWorkspaceSize(int maxBatchSize) const override { return 0; }
+  size_t getWorkspaceSize(int maxBatchSize) const noexcept override { return 0; }
 
-  int enqueue(int batchSize, const void* const* inputs, void** outputs, void* workspace, cudaStream_t stream) override {
+  int32_t enqueue(int32_t batchSize, void const* const* inputs, void* const* outputs, void* workspace,
+        cudaStream_t stream) noexcept override {
     // get input / output dimensions
     std::vector<long> batch_input_sizes = input_sizes;
     std::vector<long> batch_output_sizes = output_sizes;
@@ -227,25 +228,25 @@ public:
     return 0;
   }
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const noexcept override {
     return serializeToString().size();
   }
     
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const noexcept override {
       std::string data = serializeToString();
       size_t size = getSerializationSize();
       data.copy((char *) buffer, size);
   }
 
-  void destroy() override {}
+  void destroy() noexcept override {}
 
-  IPluginV2* clone() const override {
+  IPluginV2* clone() const noexcept override {
     return new InterpolatePlugin(size, mode, align_corners);
   }
 
-  void setPluginNamespace(const char* pluginNamespace) override {}
+  void setPluginNamespace(const char* pluginNamespace) noexcept override {}
 
-  const char *getPluginNamespace() const override {
+  const char *getPluginNamespace() const noexcept override {
     return "torch2trt";
   }
 
@@ -255,26 +256,26 @@ class InterpolatePluginCreator : public IPluginCreator {
 public:
   InterpolatePluginCreator() {}
 
-  const char *getPluginNamespace() const override {
+  const char *getPluginNamespace() const noexcept override {
     return "torch2trt";
   }
 
-  const char *getPluginName() const override {
+  const char *getPluginName() const noexcept override {
     return "interpolate";
   }
 
-  const char *getPluginVersion() const override {
+  const char *getPluginVersion() const noexcept override {
     return "1";
   }
 
-  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) override {
+  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) noexcept override {
     return new InterpolatePlugin((const char*) data, length);
   }
 
-  void setPluginNamespace(const char *N) override {}
-  const PluginFieldCollection *getFieldNames() override { return nullptr; }
+  void setPluginNamespace(const char *N) noexcept override {}
+  const PluginFieldCollection *getFieldNames() noexcept override { return nullptr; }
 
-  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) override { return nullptr; }
+  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) noexcept override { return nullptr; }
 
 };
 


### PR DESCRIPTION
Updated the plugin classes to match the latest IPluginV2 base class in TnesorRT8, which is shipped with JetPack 4.6.
https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_plugin_v2.html#af502120d140358f8d8139ade5005b9f5

Please note that this is not yet verified.