### PR TITLE
Add support for inplace mul_ operator from pytorch

### DIFF
--- a/torch2trt/converters/mul.py
+++ b/torch2trt/converters/mul.py
@@ -3,6 +3,7 @@ from torch2trt.module_test import add_module_test
 
 
 @tensorrt_converter('torch.mul')
+@tensorrt_converter('torch.Tensor.mul_')
 @tensorrt_converter('torch.Tensor.__imul__')
 @tensorrt_converter('torch.Tensor.__mul__')
 @tensorrt_converter('torch.Tensor.__rmul__')


### PR DESCRIPTION
Hi,

This change allows us to parse and convert torch.Tensor.mul_ operator (in place version of mul)
https://pytorch.org/docs/stable/generated/torch.Tensor.mul_.html

Signed-off-by: Anurag Dixit <a.dixit91@gmail.com>