### PR TITLE
Add torch.tril_indices to converters.

### DIFF
--- a/torch2trt/converters/__init__.py
+++ b/torch2trt/converters/__init__.py
@@ -65,5 +65,6 @@ from .sum import *
 from .tanh import *
 from .tensor import *
 from .transpose import *
+from .tril_indices import *
 from .unary import *
 from .view import *

--- a/torch2trt/converters/tril_indices.py
+++ b/torch2trt/converters/tril_indices.py
@@ -2,73 +2,72 @@ from torch2trt.torch2trt import *
 from torch2trt.module_test import add_module_test
 
 
+def _set_layer_precision(ctx, layer):
+    # Supported TRT precisions as given by torch2trt_kwargs.
+    INT8_MODE = "int8_mode"
+    FP16_MODE = "fp16_mode"
+
+    # Check that args exist as expected in torch2trt_kwargs.
+    trt_kwargs = ctx.torch2trt_kwargs
+    assert INT8_MODE in trt_kwargs
+    assert FP16_MODE in trt_kwargs
+
+    is_int8 = trt_kwargs.get(INT8_MODE, False)
+    is_fp16 = trt_kwargs.get(FP16_MODE, False)
+
+    if is_int8:
+        layer.precision = trt.int8
+        layer.set_output_type(0, trt.int8)
+    elif is_fp16:
+        layer.precision = trt.float16
+        layer.set_output_type(0, trt.float16)
+
+
 @tensorrt_converter('torch.tril_indices')
 def convert_tril_indices(ctx):
-    row = get_arg(ctx, 'row', 0, 0)
-    col = get_arg(ctx, 'col', 1, 0)
-    output = ctx.method_return
+    tensor = ctx.method_return
 
-    offset = get_arg(ctx, 'offset', 2, 0)
+    # Implementation mostly copied from add_trt_constant.
+    array = tensor.detach().cpu().numpy()
+    layer = ctx.network.add_constant(tensor.shape, array)
 
-    # torch.long is pytorch's default dtype for torch.tril_indices, but is not supported by tensorrt.
-    # We maintain the same default type here to allow tensorrt to error so that the user can explicitly
-    # set a different dtype instead of us implicitly changing dtypes without the user's knowledge.
-    dtype = get_arg(ctx, 'dtype', 3, torch.long)
+    _set_layer_precision(ctx, layer)
 
-    device = get_arg(ctx, 'device', 4, None) # Ignored.
-    layout = get_arg(ctx, 'layout', 5, torch.strided) # Ignored.
-
-    tril_indices = torch.tril_indices(row, col, offset=offset, dtype=dtype)
-    output._trt = add_trt_constant(ctx.network, tril_indices)
+    tensor._trt = layer.get_output(0)
 
 
 class TrilIndices(torch.nn.Module):
-    def __init__(self, row, col, offset=0, dtype=torch.long):
+    def __init__(self, row, col, offset=0):
         super().__init__()
         self.row = row
         self.col = col
         self.offset = offset
-        self.dtype = dtype
 
     def forward(self, x):
-        return x + torch.tril_indices(self.row, self.col, offset=self.offset, dtype=self.dtype, device=torch.device('cuda'))
+        return x + torch.tril_indices(self.row, self.col, offset=self.offset, dtype=torch.float32, device=torch.device('cuda'))
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 2, 6)])
 def test_tril_indices_basic():
-    return TrilIndices(3, 3, dtype=torch.float32)
+    return TrilIndices(3, 3)
 
 
-# This fails with the following error:
-# TypeError: torch.int64 is not supported by tensorrt
-#
-#  @add_module_test(torch.long, torch.device('cuda'), [(1, 2, 6)])
-#  def test_tril_indices_basic():
-    #  return TrilIndices(3, 3)
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 2, 6)], fp16_mode=True)
+def test_tril_indices_fp16_mode():
+    return TrilIndices(3, 3)
 
 
-# This fails with the following error:
-# RuntimeError: "tril_indices" not implemented for 'Half'
-#
-#  @add_module_test(torch.float16, torch.device('cuda'), [(1, 2, 6)])
-#  def test_tril_indices_float16():
-    #  return TrilIndices(3, 3, dtype=torch.float16)
-
-
-# This fails with the following error:
-# [TensorRT] ERROR: [CONSTANT #1] torch.tril_indices(3, 3, offset=0, dtype=torch.int8, device=cuda): invalid weights type of Int8
-#
-#  @add_module_test(torch.int8, torch.device('cuda'), [(1, 2, 6)])
-#  def test_tril_indices_int8():
-    #  return TrilIndices(3, 3, dtype=torch.int8)
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 2, 6)], int8_mode=True)
+def test_tril_indices_int8_mode():
+    return TrilIndices(3, 3)
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 2, 6)])
 def test_tril_indices_negative_offset():
-    return TrilIndices(4, 3, -1, dtype=torch.float32)
+    return TrilIndices(4, 3, -1)
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 2, 11)])
 def test_tril_indices_positive_offset():
-    return TrilIndices(4, 3, 1, dtype=torch.float32)
+    return TrilIndices(4, 3, 1)
 

--- a/torch2trt/converters/tril_indices.py
+++ b/torch2trt/converters/tril_indices.py
@@ -1,0 +1,74 @@
+from torch2trt.torch2trt import *
+from torch2trt.module_test import add_module_test
+
+
+@tensorrt_converter('torch.tril_indices')
+def convert_tril_indices(ctx):
+    row = get_arg(ctx, 'row', 0, 0)
+    col = get_arg(ctx, 'col', 1, 0)
+    output = ctx.method_return
+
+    offset = get_arg(ctx, 'offset', 2, 0)
+
+    # torch.long is pytorch's default dtype for torch.tril_indices, but is not supported by tensorrt.
+    # We maintain the same default type here to allow tensorrt to error so that the user can explicitly
+    # set a different dtype instead of us implicitly changing dtypes without the user's knowledge.
+    dtype = get_arg(ctx, 'dtype', 3, torch.long)
+
+    device = get_arg(ctx, 'device', 4, None) # Ignored.
+    layout = get_arg(ctx, 'layout', 5, torch.strided) # Ignored.
+
+    tril_indices = torch.tril_indices(row, col, offset=offset, dtype=dtype)
+    output._trt = add_trt_constant(ctx.network, tril_indices)
+
+
+class TrilIndices(torch.nn.Module):
+    def __init__(self, row, col, offset=0, dtype=torch.long):
+        super().__init__()
+        self.row = row
+        self.col = col
+        self.offset = offset
+        self.dtype = dtype
+
+    def forward(self, x):
+        return x + torch.tril_indices(self.row, self.col, offset=self.offset, dtype=self.dtype, device=torch.device('cuda'))
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 2, 6)])
+def test_tril_indices_basic():
+    return TrilIndices(3, 3, dtype=torch.float32)
+
+
+# This fails with the following error:
+# TypeError: torch.int64 is not supported by tensorrt
+#
+#  @add_module_test(torch.long, torch.device('cuda'), [(1, 2, 6)])
+#  def test_tril_indices_basic():
+    #  return TrilIndices(3, 3)
+
+
+# This fails with the following error:
+# RuntimeError: "tril_indices" not implemented for 'Half'
+#
+#  @add_module_test(torch.float16, torch.device('cuda'), [(1, 2, 6)])
+#  def test_tril_indices_float16():
+    #  return TrilIndices(3, 3, dtype=torch.float16)
+
+
+# This fails with the following error:
+# [TensorRT] ERROR: [CONSTANT #1] torch.tril_indices(3, 3, offset=0, dtype=torch.int8, device=cuda): invalid weights type of Int8
+#
+#  @add_module_test(torch.int8, torch.device('cuda'), [(1, 2, 6)])
+#  def test_tril_indices_int8():
+    #  return TrilIndices(3, 3, dtype=torch.int8)
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 2, 6)])
+def test_tril_indices_negative_offset():
+    return TrilIndices(4, 3, -1, dtype=torch.float32)
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 2, 11)])
+def test_tril_indices_positive_offset():
+    return TrilIndices(4, 3, 1, dtype=torch.float32)
+


### PR DESCRIPTION
Adds `torch.tril_indices` to the list of available converters.
Note that this may not be necessary, since we're just creating a constant layer here, which may be better served falling back to the original torch function.

Tested with:
```
python3 -m torch2trt.test --name tril_indices
```