### PR TITLE
Add torch.zeros to list of converters.

### DIFF
--- a/torch2trt/converters/__init__.py
+++ b/torch2trt/converters/__init__.py
@@ -67,3 +67,4 @@ from .tensor import *
 from .transpose import *
 from .unary import *
 from .view import *
+from .zeros import *

--- a/torch2trt/converters/zeros.py
+++ b/torch2trt/converters/zeros.py
@@ -2,34 +2,52 @@ from torch2trt.torch2trt import *
 from torch2trt.module_test import add_module_test
 
 
+def _set_layer_precision(ctx, layer):
+    # Supported TRT precisions as given by torch2trt_kwargs.
+    INT8_MODE = "int8_mode"
+    FP16_MODE = "fp16_mode"
+
+    # Check that args exist as expected in torch2trt_kwargs.
+    trt_kwargs = ctx.torch2trt_kwargs
+    assert INT8_MODE in trt_kwargs
+    assert FP16_MODE in trt_kwargs
+
+    is_int8 = trt_kwargs.get(INT8_MODE, False)
+    is_fp16 = trt_kwargs.get(FP16_MODE, False)
+
+    if is_int8:
+        layer.precision = trt.int8
+        layer.set_output_type(0, trt.int8)
+    elif is_fp16:
+        layer.precision = trt.float16
+        layer.set_output_type(0, trt.float16)
+
+
 @tensorrt_converter('torch.zeros')
 def convert_zeros(ctx):
-    size = ctx.method_args
-    output = ctx.method_return
+    tensor = ctx.method_return
 
-    kwargs = ctx.method_kwargs
-    out = kwargs.get('out') # Ignored.
-    dtype = kwargs.get('dtype')
-    layout = kwargs.get('layout', torch.strided) # Ignored.
-    device = kwargs.get('device') # Ignored.
-    requires_grad = kwargs.get('requires_grad', False) # Ignored.
+    # Implementation copied from add_trt_constant.
+    shape = tuple(tensor.shape[1:])
+    array = tensor[0].detach().cpu().numpy()
+    layer = ctx.network.add_constant(shape, array)
 
-    zeros_tensor = torch.zeros(*size, dtype=dtype)
-    output._trt = add_trt_constant(ctx.network, zeros_tensor)
+    _set_layer_precision(ctx, layer)
+
+    tensor._trt = layer.get_output(0)
 
 
 class Zeros(torch.nn.Module):
-    def __init__(self, *size, dtype=None):
+    def __init__(self, *size):
         super().__init__()
         self.size = size
-        self.dtype = dtype
 
     def forward(self, x):
-        return x + torch.zeros(*self.size, dtype=self.dtype, device=torch.device('cuda'))
+        return x + torch.zeros(*self.size, device=torch.device('cuda'))
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 2, 3, 4)])
-def test_zeros_basic():
+def test_zeros():
     return Zeros((1, 2, 3, 4))
 
 
@@ -38,14 +56,11 @@ def test_zeros_var_args():
     return Zeros(1, 2, 3, 4)
 
 
-@add_module_test(torch.float16, torch.device('cuda'), [(1, 2, 3, 4)])
-def test_zeros_float16():
-    return Zeros(1, 2, 3, 4, dtype=torch.float16)
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 2, 3, 4)], fp16_mode=True)
+def test_zeros_fp16_mode():
+    return Zeros(1, 2, 3, 4)
 
 
-# The fails with the following error:
-# [TensorRT] ERROR: [CONSTANT #1] torch.zeros(1, 2, 3, 4, dtype=torch.int8, device=cuda, requires_grad=False): invalid weights type of Int8
-#
-#  @add_module_test(torch.int8, torch.device('cuda'), [(1, 2, 3, 4)])
-#  def test_zeros_int8():
-    #  return Zeros(1, 2, 3, 4, dtype=torch.int8)
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 2, 3, 4)], int8_mode=True)
+def test_zeros_int8_mode():
+    return Zeros(1, 2, 3, 4)

--- a/torch2trt/converters/zeros.py
+++ b/torch2trt/converters/zeros.py
@@ -1,0 +1,51 @@
+from torch2trt.torch2trt import *
+from torch2trt.module_test import add_module_test
+
+
+@tensorrt_converter('torch.zeros')
+def convert_zeros(ctx):
+    size = ctx.method_args
+    output = ctx.method_return
+
+    kwargs = ctx.method_kwargs
+    out = kwargs.get('out') # Ignored.
+    dtype = kwargs.get('dtype')
+    layout = kwargs.get('layout', torch.strided) # Ignored.
+    device = kwargs.get('device') # Ignored.
+    requires_grad = kwargs.get('requires_grad', False) # Ignored.
+
+    zeros_tensor = torch.zeros(*size, dtype=dtype)
+    output._trt = add_trt_constant(ctx.network, zeros_tensor)
+
+
+class Zeros(torch.nn.Module):
+    def __init__(self, *size, dtype=None):
+        super().__init__()
+        self.size = size
+        self.dtype = dtype
+
+    def forward(self, x):
+        return x + torch.zeros(*self.size, dtype=self.dtype, device=torch.device('cuda'))
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 2, 3, 4)])
+def test_zeros_basic():
+    return Zeros((1, 2, 3, 4))
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 2, 3, 4)])
+def test_zeros_var_args():
+    return Zeros(1, 2, 3, 4)
+
+
+@add_module_test(torch.float16, torch.device('cuda'), [(1, 2, 3, 4)])
+def test_zeros_float16():
+    return Zeros(1, 2, 3, 4, dtype=torch.float16)
+
+
+# The fails with the following error:
+# [TensorRT] ERROR: [CONSTANT #1] torch.zeros(1, 2, 3, 4, dtype=torch.int8, device=cuda, requires_grad=False): invalid weights type of Int8
+#
+#  @add_module_test(torch.int8, torch.device('cuda'), [(1, 2, 3, 4)])
+#  def test_zeros_int8():
+    #  return Zeros(1, 2, 3, 4, dtype=torch.int8)


### PR DESCRIPTION
Adds `torch.zeros` to list of available converters.
Note that this may not be necessary, since we're just creating a constant layer here, which may be better served falling back to the original torch function.

Tested with:
```
python3 -m torch2trt.test --name zeros
```