### PR TITLE
Rebase and merge jp4.6_tensorrt8 onto latest master.

### DIFF
--- a/torch2trt/plugins/group_norm.cpp
+++ b/torch2trt/plugins/group_norm.cpp
@@ -112,19 +112,19 @@ public:
         return data_str.str();
     }
     
-    const char* getPluginType() const override {
+    const char* getPluginType() const noexcept override {
       return "group_norm";
     };
 
-    const char* getPluginVersion() const override {
+    const char* getPluginVersion() const noexcept override {
       return "1";
     }
 
-    int getNbOutputs() const override {
+    int getNbOutputs() const noexcept override {
       return 1;
     } 
 
-    Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
+    Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) noexcept override {
       Dims dims;
       dims.nbDims = inputs->nbDims;
   
@@ -135,8 +135,8 @@ public:
       return dims;
     }
 
-    bool supportsFormat(DataType type, PluginFormat format) const override {
-      if (format != PluginFormat::kNCHW) {
+    bool supportsFormat(DataType type, PluginFormat format) const noexcept override {
+      if (format != PluginFormat::kLINEAR) {
         return false;
       }
       if (type == DataType::kINT32 || type == DataType::kINT8) {
@@ -146,7 +146,7 @@ public:
     }
 
   void configureWithFormat(const Dims* inputDims, int nbInputs, const Dims* outputDims,
-      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) override {
+      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) noexcept override {
     
     // set data type
     if (type == DataType::kFLOAT) {
@@ -170,7 +170,7 @@ public:
     }
   }
 
-  int initialize() override {
+  int initialize() noexcept override {
     // set device
     tensor_options = tensor_options.device(c10::kCUDA);
       
@@ -188,11 +188,12 @@ public:
     return 0;
   }
 
-  void terminate() override {}
+  void terminate() noexcept override {}
 
-  size_t getWorkspaceSize(int maxBatchSize) const override { return 0; }
+  size_t getWorkspaceSize(int maxBatchSize) const noexcept override { return 0; }
 
-  int enqueue(int batchSize, const void* const* inputs, void** outputs, void* workspace, cudaStream_t stream) override {
+  int32_t enqueue(int32_t batchSize, void const* const* inputs, void* const* outputs, void* workspace,
+        cudaStream_t stream) noexcept override {
     // get input / output dimensions
     std::vector<long> batch_input_sizes = input_sizes;
     std::vector<long> batch_output_sizes = output_sizes;
@@ -235,25 +236,25 @@ public:
   }
 
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const noexcept override {
     return serializeToString().size();
   }
     
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const noexcept override {
       std::string data = serializeToString();
       size_t size = getSerializationSize();
       data.copy((char *) buffer, size);
   }
 
-  void destroy() override {}
+  void destroy() noexcept override {}
 
-  IPluginV2* clone() const override {
+  IPluginV2* clone() const noexcept override {
     return new GroupNormPlugin(num_groups, weight, bias, eps); 
   }
 
-  void setPluginNamespace(const char* pluginNamespace) override {}
+  void setPluginNamespace(const char* pluginNamespace) noexcept override {}
 
-  const char *getPluginNamespace() const override {
+  const char *getPluginNamespace() const noexcept override {
     return "torch2trt";
   }
 
@@ -263,26 +264,26 @@ class GroupNormPluginCreator : public IPluginCreator {
 public:
   GroupNormPluginCreator() {}
 
-  const char *getPluginNamespace() const override {
+  const char *getPluginNamespace() const noexcept override {
     return "torch2trt";
   }
 
-  const char *getPluginName() const override {
+  const char *getPluginName() const noexcept override {
     return "group_norm";
   }
 
-  const char *getPluginVersion() const override {
+  const char *getPluginVersion() const noexcept override {
     return "1";
   }
 
-  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) override {
+  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) noexcept override {
     return new GroupNormPlugin((const char*) data, length);
   }
 
-  void setPluginNamespace(const char *N) override {}
-  const PluginFieldCollection *getFieldNames() override { return nullptr; }
+  void setPluginNamespace(const char *N) noexcept override {}
+  const PluginFieldCollection *getFieldNames() noexcept override { return nullptr; }
 
-  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) override { return nullptr; }
+  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) noexcept override { return nullptr; }
 
 };
 

--- a/torch2trt/plugins/interpolate.cpp
+++ b/torch2trt/plugins/interpolate.cpp
@@ -103,19 +103,19 @@ public:
       return data_str.str();
   }
 
-  const char* getPluginType() const override {
+  const char* getPluginType() const noexcept override {
     return "interpolate";
   };
 
-  const char* getPluginVersion() const override {
+  const char* getPluginVersion() const noexcept override {
     return "1";
   }
 
-  int getNbOutputs() const override {
+  int getNbOutputs() const noexcept override {
     return 1;
   } 
 
-  Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
+  Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) noexcept override {
     Dims dims;
     dims.nbDims = inputs->nbDims;
 
@@ -127,8 +127,8 @@ public:
     return dims;
   }
 
-  bool supportsFormat(DataType type, PluginFormat format) const override {
-    if (format != PluginFormat::kNCHW) {
+  bool supportsFormat(DataType type, PluginFormat format) const noexcept override {
+    if (format != PluginFormat::kLINEAR) {
       return false;
     }
     if (type == DataType::kINT32 || type == DataType::kINT8) {
@@ -138,7 +138,7 @@ public:
   }
 
   void configureWithFormat(const Dims* inputDims, int nbInputs, const Dims* outputDims,
-      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) override {
+      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) noexcept override {
     
     // set data type
     if (type == DataType::kFLOAT) {
@@ -162,7 +162,7 @@ public:
     }
   }
 
-  int initialize() override {
+  int initialize() noexcept override {
     // set device
     tensor_options = tensor_options.device(c10::kCUDA);
       
@@ -176,11 +176,12 @@ public:
     return 0;
   }
 
-  void terminate() override {}
+  void terminate() noexcept override {}
 
-  size_t getWorkspaceSize(int maxBatchSize) const override { return 0; }
+  size_t getWorkspaceSize(int maxBatchSize) const noexcept override { return 0; }
 
-  int enqueue(int batchSize, const void* const* inputs, void** outputs, void* workspace, cudaStream_t stream) override {
+  int32_t enqueue(int32_t batchSize, void const* const* inputs, void* const* outputs, void* workspace,
+        cudaStream_t stream) noexcept override {
     // get input / output dimensions
     std::vector<long> batch_input_sizes = input_sizes;
     std::vector<long> batch_output_sizes = output_sizes;
@@ -227,25 +228,25 @@ public:
     return 0;
   }
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const noexcept override {
     return serializeToString().size();
   }
     
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const noexcept override {
       std::string data = serializeToString();
       size_t size = getSerializationSize();
       data.copy((char *) buffer, size);
   }
 
-  void destroy() override {}
+  void destroy() noexcept override {}
 
-  IPluginV2* clone() const override {
+  IPluginV2* clone() const noexcept override {
     return new InterpolatePlugin(size, mode, align_corners);
   }
 
-  void setPluginNamespace(const char* pluginNamespace) override {}
+  void setPluginNamespace(const char* pluginNamespace) noexcept override {}
 
-  const char *getPluginNamespace() const override {
+  const char *getPluginNamespace() const noexcept override {
     return "torch2trt";
   }
 
@@ -255,26 +256,26 @@ class InterpolatePluginCreator : public IPluginCreator {
 public:
   InterpolatePluginCreator() {}
 
-  const char *getPluginNamespace() const override {
+  const char *getPluginNamespace() const noexcept override {
     return "torch2trt";
   }
 
-  const char *getPluginName() const override {
+  const char *getPluginName() const noexcept override {
     return "interpolate";
   }
 
-  const char *getPluginVersion() const override {
+  const char *getPluginVersion() const noexcept override {
     return "1";
   }
 
-  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) override {
+  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) noexcept override {
     return new InterpolatePlugin((const char*) data, length);
   }
 
-  void setPluginNamespace(const char *N) override {}
-  const PluginFieldCollection *getFieldNames() override { return nullptr; }
+  void setPluginNamespace(const char *N) noexcept override {}
+  const PluginFieldCollection *getFieldNames() noexcept override { return nullptr; }
 
-  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) override { return nullptr; }
+  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) noexcept override { return nullptr; }
 
 };
 

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -577,7 +577,7 @@ def torch2trt(module,
                     inputs, int8_calib_dataset, batch_size=int8_calib_batch_size, algorithm=int8_calib_algorithm
                 )
 
-    engine = builder.build_engine(network)
+    engine = builder.build_engine(network, config)
 
     module_trt = TRTModule(engine, input_names, output_names)
 

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -577,7 +577,7 @@ def torch2trt(module,
                     inputs, int8_calib_dataset, batch_size=int8_calib_batch_size, algorithm=int8_calib_algorithm
                 )
 
-    engine = builder.build_engine(network, config)
+    engine = builder.build_engine(network)
 
     module_trt = TRTModule(engine, input_names, output_names)
 

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -518,7 +518,7 @@ def torch2trt(module,
     logger = trt.Logger(log_level)
     builder = trt.Builder(logger)
     config = builder.create_builder_config()
-    
+
     if isinstance(inputs, list):
         inputs = tuple(inputs)
     if not isinstance(inputs, tuple):
@@ -555,34 +555,28 @@ def torch2trt(module,
             if not isinstance(outputs, tuple) and not isinstance(outputs, list):
                 outputs = (outputs,)
             ctx.mark_outputs(outputs, output_names)
-    
-    # set max workspace size
+
+    config = builder.create_builder_config()
     config.max_workspace_size = max_workspace_size
-    
-    if fp16_mode:
-        config.set_flag(trt.BuilderFlag.FP16)
-        
+    config.flags = fp16_mode << int(trt.BuilderFlag.FP16)
+    config.flags = strict_type_constraints << int(trt.BuilderFlag.STRICT_TYPES)
     builder.max_batch_size = max_batch_size
-    
-    if strict_type_constraints:
-        config.set_flag(trt.BuilderFlag.STRICT_TYPES)
 
     if int8_mode:
 
         # default to use input tensors for calibration
         if int8_calib_dataset is None:
             int8_calib_dataset = TensorBatchDataset(inputs_in)
-        
+
         config.set_flag(trt.BuilderFlag.INT8)
-        
-        #Making sure not to run calibration with QAT mode on 
+
+        #Making sure not to run calibration with QAT mode on
         if not 'qat_mode' in kwargs:
-        # @TODO(jwelsh):  Should we set batch_size=max_batch_size?  Need to investigate memory consumption
-            calibrator = DatasetCalibrator(
-                inputs, int8_calib_dataset, batch_size=int8_calib_batch_size, algorithm=int8_calib_algorithm
-            )
-            config.int8_calibrator = calibrator
-        
+            # @TODO(jwelsh):  Should we set batch_size=max_batch_size?  Need to investigate memory consumption
+                builder.int8_calibrator = DatasetCalibrator(
+                    inputs, int8_calib_dataset, batch_size=int8_calib_batch_size, algorithm=int8_calib_algorithm
+                )
+
     engine = builder.build_engine(network, config)
 
     module_trt = TRTModule(engine, input_names, output_names)

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -517,7 +517,6 @@ def torch2trt(module,
 
     logger = trt.Logger(log_level)
     builder = trt.Builder(logger)
-    config = builder.create_builder_config()
 
     if isinstance(inputs, list):
         inputs = tuple(inputs)
@@ -568,14 +567,14 @@ def torch2trt(module,
         if int8_calib_dataset is None:
             int8_calib_dataset = TensorBatchDataset(inputs_in)
 
-        config.set_flag(trt.BuilderFlag.INT8)
+        config.flags = int8_mode << int(trt.BuilderFlag.INT8)
 
         #Making sure not to run calibration with QAT mode on
         if not 'qat_mode' in kwargs:
             # @TODO(jwelsh):  Should we set batch_size=max_batch_size?  Need to investigate memory consumption
-                builder.int8_calibrator = DatasetCalibrator(
-                    inputs, int8_calib_dataset, batch_size=int8_calib_batch_size, algorithm=int8_calib_algorithm
-                )
+            builder.int8_calibrator = DatasetCalibrator(
+                inputs, int8_calib_dataset, batch_size=int8_calib_batch_size, algorithm=int8_calib_algorithm
+            )
 
     engine = builder.build_engine(network, config)
 


### PR DESCRIPTION
- Update plugin classes to match the base IPluginV2 class in TensorRT8
- Cherry-pick from gcunhase/torch2trt
- Cherry-pick from gcunhase/torch2trt
- Cherry-pick from gcunhase/torch2trt
- Update plugin classes to match the base IPluginV2 class in TensorRT8
- Cherry-pick from gcunhase/torch2trt
- Cherry-pick from gcunhase/torch2trt
- Cherry-pick from gcunhase/torch2trt
- Fix rebase issues, add support for int8 flags.
