### PR TITLE
Rebase chitoku/jp4.6_tensorrt8 onto latest master. Make it backwards compatible for TRT v6.x-8.x.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import sys
+import tensorrt
 import torch
 from setuptools import setup, find_packages
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension, CppExtension
@@ -12,8 +13,14 @@ def trt_lib_dir():
 ext_modules = []
 exclude_dir = ["torch2trt/contrib","torch2trt/contrib.*"]
 
+compile_args_cxx = []
+if torch.__version__ < '1.5':
+    compile_args_cxx.append('-DUSE_DEPRECATED_INTLIST')
+if tensorrt.__version__ < '8':
+    compile_args_cxx.append('-DPRE_TRT8')
+
 plugins_ext_module = CUDAExtension(
-        name='plugins', 
+        name='plugins',
         sources=[
             'torch2trt/plugins/plugins.cpp'
         ],
@@ -27,7 +34,7 @@ plugins_ext_module = CUDAExtension(
             'nvinfer'
         ],
         extra_compile_args={
-            'cxx': ['-DUSE_DEPRECATED_INTLIST'] if torch.__version__ < "1.5" else [],
+            'cxx': compile_args_cxx,
             'nvcc': []
         }
     )
@@ -36,7 +43,7 @@ if '--plugins' in sys.argv:
     sys.argv.remove('--plugins')
 
 if '--contrib' in sys.argv:
-    exclude_dir=[] 
+    exclude_dir=[]
     sys.argv.remove('--contrib')
 
 setup(

--- a/torch2trt/plugins/group_norm.cpp
+++ b/torch2trt/plugins/group_norm.cpp
@@ -112,19 +112,19 @@ public:
         return data_str.str();
     }
     
-    const char* getPluginType() const override {
+    const char* getPluginType() const noexcept override {
       return "group_norm";
     };
 
-    const char* getPluginVersion() const override {
+    const char* getPluginVersion() const noexcept override {
       return "1";
     }
 
-    int getNbOutputs() const override {
+    int getNbOutputs() const noexcept override {
       return 1;
     } 
 
-    Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
+    Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) noexcept override {
       Dims dims;
       dims.nbDims = inputs->nbDims;
   
@@ -135,8 +135,8 @@ public:
       return dims;
     }
 
-    bool supportsFormat(DataType type, PluginFormat format) const override {
-      if (format != PluginFormat::kNCHW) {
+    bool supportsFormat(DataType type, PluginFormat format) const noexcept override {
+      if (format != PluginFormat::kLINEAR) {
         return false;
       }
       if (type == DataType::kINT32 || type == DataType::kINT8) {
@@ -146,7 +146,7 @@ public:
     }
 
   void configureWithFormat(const Dims* inputDims, int nbInputs, const Dims* outputDims,
-      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) override {
+      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) noexcept override {
     
     // set data type
     if (type == DataType::kFLOAT) {
@@ -170,7 +170,7 @@ public:
     }
   }
 
-  int initialize() override {
+  int initialize() noexcept override {
     // set device
     tensor_options = tensor_options.device(c10::kCUDA);
       
@@ -188,11 +188,12 @@ public:
     return 0;
   }
 
-  void terminate() override {}
+  void terminate() noexcept override {}
 
-  size_t getWorkspaceSize(int maxBatchSize) const override { return 0; }
+  size_t getWorkspaceSize(int maxBatchSize) const noexcept override { return 0; }
 
-  int enqueue(int batchSize, const void* const* inputs, void** outputs, void* workspace, cudaStream_t stream) override {
+  int32_t enqueue(int32_t batchSize, void const* const* inputs, void* const* outputs, void* workspace,
+        cudaStream_t stream) noexcept override {
     // get input / output dimensions
     std::vector<long> batch_input_sizes = input_sizes;
     std::vector<long> batch_output_sizes = output_sizes;
@@ -235,25 +236,25 @@ public:
   }
 
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const noexcept override {
     return serializeToString().size();
   }
     
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const noexcept override {
       std::string data = serializeToString();
       size_t size = getSerializationSize();
       data.copy((char *) buffer, size);
   }
 
-  void destroy() override {}
+  void destroy() noexcept override {}
 
-  IPluginV2* clone() const override {
+  IPluginV2* clone() const noexcept override {
     return new GroupNormPlugin(num_groups, weight, bias, eps); 
   }
 
-  void setPluginNamespace(const char* pluginNamespace) override {}
+  void setPluginNamespace(const char* pluginNamespace) noexcept override {}
 
-  const char *getPluginNamespace() const override {
+  const char *getPluginNamespace() const noexcept override {
     return "torch2trt";
   }
 
@@ -263,26 +264,26 @@ class GroupNormPluginCreator : public IPluginCreator {
 public:
   GroupNormPluginCreator() {}
 
-  const char *getPluginNamespace() const override {
+  const char *getPluginNamespace() const noexcept override {
     return "torch2trt";
   }
 
-  const char *getPluginName() const override {
+  const char *getPluginName() const noexcept override {
     return "group_norm";
   }
 
-  const char *getPluginVersion() const override {
+  const char *getPluginVersion() const noexcept override {
     return "1";
   }
 
-  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) override {
+  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) noexcept override {
     return new GroupNormPlugin((const char*) data, length);
   }
 
-  void setPluginNamespace(const char *N) override {}
-  const PluginFieldCollection *getFieldNames() override { return nullptr; }
+  void setPluginNamespace(const char *N) noexcept override {}
+  const PluginFieldCollection *getFieldNames() noexcept override { return nullptr; }
 
-  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) override { return nullptr; }
+  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) noexcept override { return nullptr; }
 
 };
 

--- a/torch2trt/plugins/group_norm.cpp
+++ b/torch2trt/plugins/group_norm.cpp
@@ -9,6 +9,12 @@
 #include <torch/torch.h>
 #include <cuda_runtime_api.h>
 
+#ifdef PRE_TRT8
+#define TRT_NOEXCEPT
+#else
+#define TRT_NOEXCEPT noexcept
+#endif
+
 using namespace nvinfer1;
 
 namespace torch2trt {
@@ -26,12 +32,12 @@ private:
     at::Tensor weight;
     at::Tensor bias;
     double eps;
-    
+
 
 public:
 
     // create from arguments
-    GroupNormPlugin(int64_t num_groups, at::Tensor weight, at::Tensor bias, double eps) : 
+    GroupNormPlugin(int64_t num_groups, at::Tensor weight, at::Tensor bias, double eps) :
             num_groups{num_groups}, weight{weight}, bias{bias}, eps{eps}
     {}
 
@@ -52,7 +58,7 @@ public:
             num_groups = value.toIntListRef().vec();
 #else
             num_groups = value.toInt();
-#endif  
+#endif
         }
 	{
             torch::IValue value;
@@ -72,7 +78,7 @@ public:
             eps = value.toDoubleListRef().vec();
 #else
             eps = value.toDouble();
-#endif  
+#endif
         }
 	{
             torch::IValue value;
@@ -86,7 +92,7 @@ public:
             input_sizes = value.toIntListRef().vec();
 #else
             input_sizes = value.toIntVector();
-#endif  
+#endif
         }
         {
             torch::IValue value;
@@ -95,7 +101,7 @@ public:
             output_sizes = value.toIntListRef().vec();
 #else
             output_sizes = value.toIntVector();
-#endif  
+#endif
         }
     }
     std::string serializeToString() const {
@@ -111,31 +117,31 @@ public:
         output_archive.save_to(data_str);
         return data_str.str();
     }
-    
-    const char* getPluginType() const noexcept override {
+
+    const char* getPluginType() const TRT_NOEXCEPT override {
       return "group_norm";
     };
 
-    const char* getPluginVersion() const noexcept override {
+    const char* getPluginVersion() const TRT_NOEXCEPT override {
       return "1";
     }
 
-    int getNbOutputs() const noexcept override {
+    int getNbOutputs() const TRT_NOEXCEPT override {
       return 1;
-    } 
+    }
 
-    Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) noexcept override {
+    Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) TRT_NOEXCEPT override {
       Dims dims;
       dims.nbDims = inputs->nbDims;
-  
+
       for (int i = 0; i < inputs->nbDims; i++) {
         dims.d[i] = inputs->d[i];
       }
-  
+
       return dims;
     }
 
-    bool supportsFormat(DataType type, PluginFormat format) const noexcept override {
+    bool supportsFormat(DataType type, PluginFormat format) const TRT_NOEXCEPT override {
       if (format != PluginFormat::kLINEAR) {
         return false;
       }
@@ -146,8 +152,8 @@ public:
     }
 
   void configureWithFormat(const Dims* inputDims, int nbInputs, const Dims* outputDims,
-      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) noexcept override {
-    
+      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) TRT_NOEXCEPT override {
+
     // set data type
     if (type == DataType::kFLOAT) {
       tensor_options = tensor_options.dtype(c10::kFloat);
@@ -156,7 +162,7 @@ public:
       tensor_options = tensor_options.dtype(c10::kHalf);
       dtype = type;
     }
-      
+
     // set input sizes
     input_sizes.resize(inputDims[0].nbDims);
     for (int i = 0; i < inputDims[0].nbDims; i++) {
@@ -170,30 +176,34 @@ public:
     }
   }
 
-  int initialize() noexcept override {
+  int initialize() TRT_NOEXCEPT override {
     // set device
     tensor_options = tensor_options.device(c10::kCUDA);
-      
+
     // set data type
     if (dtype == DataType::kFLOAT) {
         tensor_options = tensor_options.dtype(c10::kFloat);
     } else if (dtype == DataType::kHALF) {
         tensor_options = tensor_options.dtype(c10::kHalf);
     }
-      
-      
+
+
     weight = weight.to(tensor_options);
     bias = bias.to(tensor_options);
-      
+
     return 0;
   }
 
-  void terminate() noexcept override {}
+  void terminate() TRT_NOEXCEPT override {}
 
-  size_t getWorkspaceSize(int maxBatchSize) const noexcept override { return 0; }
+  size_t getWorkspaceSize(int maxBatchSize) const TRT_NOEXCEPT override { return 0; }
 
-  int32_t enqueue(int32_t batchSize, void const* const* inputs, void* const* outputs, void* workspace,
+#ifdef PRE_TRT8
+int enqueue(int batchSize, const void* const* inputs, void** outputs, void* workspace, cudaStream_t stream) override {
+#else
+int32_t enqueue(int32_t batchSize, void const* const* inputs, void* const* outputs, void* workspace,
         cudaStream_t stream) noexcept override {
+#endif
     // get input / output dimensions
     std::vector<long> batch_input_sizes = input_sizes;
     std::vector<long> batch_output_sizes = output_sizes;
@@ -202,8 +212,8 @@ public:
 
     // create tensor wrappers
     at::Tensor input = at::from_blob((void*) inputs[0], batch_input_sizes, [](void*){}, tensor_options);
-    at::Tensor output = at::from_blob(outputs[0], batch_output_sizes, [](void*){}, tensor_options); 
-    
+    at::Tensor output = at::from_blob(outputs[0], batch_output_sizes, [](void*){}, tensor_options);
+
     // create new torch cuda stream
     at::cuda::CUDAStream torch_stream = at::cuda::getStreamFromPool();
     at::cuda::CUDAStreamGuard torch_guard(torch_stream);
@@ -215,14 +225,14 @@ public:
 
     // make torch cuda stream wait on tensorrt work
     cudaStreamWaitEvent(torch_stream.stream(), event, 0);
-      
-      
+
+
 
     // enqueue work
     // Group_norm function from PyTorch: https://pytorch.org/cppdocs/api/function_namespaceat_1a6bc1e9504ea440c6c96ff8a8b94333f2.html#exhale-function-namespaceat-1a6bc1e9504ea440c6c96ff8a8b94333f2
     at::Tensor output_tmp = at::group_norm(input, num_groups, weight, bias, eps=eps);
     output.copy_(output_tmp);
-      
+
     // capture event on enqueued stream
     cudaEvent_t torch_event;
     cudaEventCreate(&torch_event);
@@ -236,25 +246,25 @@ public:
   }
 
 
-  size_t getSerializationSize() const noexcept override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return serializeToString().size();
   }
-    
-  void serialize(void* buffer) const noexcept override {
+
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
       std::string data = serializeToString();
       size_t size = getSerializationSize();
       data.copy((char *) buffer, size);
   }
 
-  void destroy() noexcept override {}
+  void destroy() TRT_NOEXCEPT override {}
 
-  IPluginV2* clone() const noexcept override {
-    return new GroupNormPlugin(num_groups, weight, bias, eps); 
+  IPluginV2* clone() const TRT_NOEXCEPT override {
+    return new GroupNormPlugin(num_groups, weight, bias, eps);
   }
 
-  void setPluginNamespace(const char* pluginNamespace) noexcept override {}
+  void setPluginNamespace(const char* pluginNamespace) TRT_NOEXCEPT override {}
 
-  const char *getPluginNamespace() const noexcept override {
+  const char *getPluginNamespace() const TRT_NOEXCEPT override {
     return "torch2trt";
   }
 
@@ -264,32 +274,32 @@ class GroupNormPluginCreator : public IPluginCreator {
 public:
   GroupNormPluginCreator() {}
 
-  const char *getPluginNamespace() const noexcept override {
+  const char *getPluginNamespace() const TRT_NOEXCEPT override {
     return "torch2trt";
   }
 
-  const char *getPluginName() const noexcept override {
+  const char *getPluginName() const TRT_NOEXCEPT override {
     return "group_norm";
   }
 
-  const char *getPluginVersion() const noexcept override {
+  const char *getPluginVersion() const TRT_NOEXCEPT override {
     return "1";
   }
 
-  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) noexcept override {
+  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) TRT_NOEXCEPT override {
     return new GroupNormPlugin((const char*) data, length);
   }
 
-  void setPluginNamespace(const char *N) noexcept override {}
-  const PluginFieldCollection *getFieldNames() noexcept override { return nullptr; }
+  void setPluginNamespace(const char *N) TRT_NOEXCEPT override {}
+  const PluginFieldCollection *getFieldNames() TRT_NOEXCEPT override { return nullptr; }
 
-  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) noexcept override { return nullptr; }
+  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) TRT_NOEXCEPT override { return nullptr; }
 
 };
 
 
 REGISTER_TENSORRT_PLUGIN(GroupNormPluginCreator);
-    
+
 } // namespace torch2trt
 
 

--- a/torch2trt/plugins/interpolate.cpp
+++ b/torch2trt/plugins/interpolate.cpp
@@ -103,19 +103,19 @@ public:
       return data_str.str();
   }
 
-  const char* getPluginType() const override {
+  const char* getPluginType() const noexcept override {
     return "interpolate";
   };
 
-  const char* getPluginVersion() const override {
+  const char* getPluginVersion() const noexcept override {
     return "1";
   }
 
-  int getNbOutputs() const override {
+  int getNbOutputs() const noexcept override {
     return 1;
   } 
 
-  Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
+  Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) noexcept override {
     Dims dims;
     dims.nbDims = inputs->nbDims;
 
@@ -127,8 +127,8 @@ public:
     return dims;
   }
 
-  bool supportsFormat(DataType type, PluginFormat format) const override {
-    if (format != PluginFormat::kNCHW) {
+  bool supportsFormat(DataType type, PluginFormat format) const noexcept override {
+    if (format != PluginFormat::kLINEAR) {
       return false;
     }
     if (type == DataType::kINT32 || type == DataType::kINT8) {
@@ -138,7 +138,7 @@ public:
   }
 
   void configureWithFormat(const Dims* inputDims, int nbInputs, const Dims* outputDims,
-      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) override {
+      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) noexcept override {
     
     // set data type
     if (type == DataType::kFLOAT) {
@@ -162,7 +162,7 @@ public:
     }
   }
 
-  int initialize() override {
+  int initialize() noexcept override {
     // set device
     tensor_options = tensor_options.device(c10::kCUDA);
       
@@ -176,11 +176,12 @@ public:
     return 0;
   }
 
-  void terminate() override {}
+  void terminate() noexcept override {}
 
-  size_t getWorkspaceSize(int maxBatchSize) const override { return 0; }
+  size_t getWorkspaceSize(int maxBatchSize) const noexcept override { return 0; }
 
-  int enqueue(int batchSize, const void* const* inputs, void** outputs, void* workspace, cudaStream_t stream) override {
+  int32_t enqueue(int32_t batchSize, void const* const* inputs, void* const* outputs, void* workspace,
+        cudaStream_t stream) noexcept override {
     // get input / output dimensions
     std::vector<long> batch_input_sizes = input_sizes;
     std::vector<long> batch_output_sizes = output_sizes;
@@ -227,25 +228,25 @@ public:
     return 0;
   }
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const noexcept override {
     return serializeToString().size();
   }
     
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const noexcept override {
       std::string data = serializeToString();
       size_t size = getSerializationSize();
       data.copy((char *) buffer, size);
   }
 
-  void destroy() override {}
+  void destroy() noexcept override {}
 
-  IPluginV2* clone() const override {
+  IPluginV2* clone() const noexcept override {
     return new InterpolatePlugin(size, mode, align_corners);
   }
 
-  void setPluginNamespace(const char* pluginNamespace) override {}
+  void setPluginNamespace(const char* pluginNamespace) noexcept override {}
 
-  const char *getPluginNamespace() const override {
+  const char *getPluginNamespace() const noexcept override {
     return "torch2trt";
   }
 
@@ -255,26 +256,26 @@ class InterpolatePluginCreator : public IPluginCreator {
 public:
   InterpolatePluginCreator() {}
 
-  const char *getPluginNamespace() const override {
+  const char *getPluginNamespace() const noexcept override {
     return "torch2trt";
   }
 
-  const char *getPluginName() const override {
+  const char *getPluginName() const noexcept override {
     return "interpolate";
   }
 
-  const char *getPluginVersion() const override {
+  const char *getPluginVersion() const noexcept override {
     return "1";
   }
 
-  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) override {
+  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) noexcept override {
     return new InterpolatePlugin((const char*) data, length);
   }
 
-  void setPluginNamespace(const char *N) override {}
-  const PluginFieldCollection *getFieldNames() override { return nullptr; }
+  void setPluginNamespace(const char *N) noexcept override {}
+  const PluginFieldCollection *getFieldNames() noexcept override { return nullptr; }
 
-  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) override { return nullptr; }
+  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) noexcept override { return nullptr; }
 
 };
 

--- a/torch2trt/plugins/interpolate.cpp
+++ b/torch2trt/plugins/interpolate.cpp
@@ -9,39 +9,45 @@
 #include <torch/torch.h>
 #include <cuda_runtime_api.h>
 
+#ifdef PRE_TRT8
+#define TRT_NOEXCEPT
+#else
+#define TRT_NOEXCEPT noexcept
+#endif
+
 using namespace nvinfer1;
 
 namespace torch2trt {
 
-    
+
 class InterpolatePlugin : public IPluginV2 {
 private:
-    
+
   // configured by class
   at::TensorOptions tensor_options;
   std::vector<int64_t> input_sizes;
   std::vector<int64_t> output_sizes;
   DataType dtype;
-    
+
   // configured by user
   std::vector<int64_t> size;
   std::string mode;
   bool align_corners;
 
 public:
-    
+
   // create from arguments
   InterpolatePlugin(std::vector<int64_t> size, std::string mode, bool align_corners) :
     size(size), mode(mode), align_corners(align_corners)
   {}
-    
+
   InterpolatePlugin(const char *data, size_t length) : InterpolatePlugin(std::string(data, length)) {}
-    
+
   // create from serialized data
   InterpolatePlugin(const std::string &data) {
       deserializeFromString(data);
   }
-   
+
   void deserializeFromString(const std::string &data) {
       std::istringstream data_stream(data);
       torch::serialize::InputArchive input_archive;
@@ -89,7 +95,7 @@ public:
 #endif
       }
   }
-    
+
   std::string serializeToString() const {
       torch::serialize::OutputArchive output_archive;
       output_archive.write("size", torch::IValue(size));
@@ -103,19 +109,19 @@ public:
       return data_str.str();
   }
 
-  const char* getPluginType() const noexcept override {
+  const char* getPluginType() const TRT_NOEXCEPT override {
     return "interpolate";
   };
 
-  const char* getPluginVersion() const noexcept override {
+  const char* getPluginVersion() const TRT_NOEXCEPT override {
     return "1";
   }
 
-  int getNbOutputs() const noexcept override {
+  int getNbOutputs() const TRT_NOEXCEPT override {
     return 1;
-  } 
+  }
 
-  Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) noexcept override {
+  Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) TRT_NOEXCEPT override {
     Dims dims;
     dims.nbDims = inputs->nbDims;
 
@@ -127,7 +133,7 @@ public:
     return dims;
   }
 
-  bool supportsFormat(DataType type, PluginFormat format) const noexcept override {
+  bool supportsFormat(DataType type, PluginFormat format) const TRT_NOEXCEPT override {
     if (format != PluginFormat::kLINEAR) {
       return false;
     }
@@ -138,8 +144,8 @@ public:
   }
 
   void configureWithFormat(const Dims* inputDims, int nbInputs, const Dims* outputDims,
-      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) noexcept override {
-    
+      int nbOutputs, DataType type, PluginFormat format, int maxBatchSize) TRT_NOEXCEPT override {
+
     // set data type
     if (type == DataType::kFLOAT) {
       tensor_options = tensor_options.dtype(c10::kFloat);
@@ -148,7 +154,7 @@ public:
       tensor_options = tensor_options.dtype(c10::kHalf);
       dtype = type;
     }
-      
+
     // set input sizes
     input_sizes.resize(inputDims[0].nbDims);
     for (int i = 0; i < inputDims[0].nbDims; i++) {
@@ -162,26 +168,30 @@ public:
     }
   }
 
-  int initialize() noexcept override {
+  int initialize() TRT_NOEXCEPT override {
     // set device
     tensor_options = tensor_options.device(c10::kCUDA);
-      
+
     // set data type
     if (dtype == DataType::kFLOAT) {
         tensor_options = tensor_options.dtype(c10::kFloat);
     } else if (dtype == DataType::kHALF) {
         tensor_options = tensor_options.dtype(c10::kHalf);
     }
-      
+
     return 0;
   }
 
-  void terminate() noexcept override {}
+  void terminate() TRT_NOEXCEPT override {}
 
-  size_t getWorkspaceSize(int maxBatchSize) const noexcept override { return 0; }
+  size_t getWorkspaceSize(int maxBatchSize) const TRT_NOEXCEPT override { return 0; }
 
-  int32_t enqueue(int32_t batchSize, void const* const* inputs, void* const* outputs, void* workspace,
+#ifdef PRE_TRT8
+int enqueue(int batchSize, const void* const* inputs, void** outputs, void* workspace, cudaStream_t stream) override {
+#else
+int32_t enqueue(int32_t batchSize, void const* const* inputs, void* const* outputs, void* workspace,
         cudaStream_t stream) noexcept override {
+#endif
     // get input / output dimensions
     std::vector<long> batch_input_sizes = input_sizes;
     std::vector<long> batch_output_sizes = output_sizes;
@@ -228,25 +238,25 @@ public:
     return 0;
   }
 
-  size_t getSerializationSize() const noexcept override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return serializeToString().size();
   }
-    
-  void serialize(void* buffer) const noexcept override {
+
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
       std::string data = serializeToString();
       size_t size = getSerializationSize();
       data.copy((char *) buffer, size);
   }
 
-  void destroy() noexcept override {}
+  void destroy() TRT_NOEXCEPT override {}
 
-  IPluginV2* clone() const noexcept override {
+  IPluginV2* clone() const TRT_NOEXCEPT override {
     return new InterpolatePlugin(size, mode, align_corners);
   }
 
-  void setPluginNamespace(const char* pluginNamespace) noexcept override {}
+  void setPluginNamespace(const char* pluginNamespace) TRT_NOEXCEPT override {}
 
-  const char *getPluginNamespace() const noexcept override {
+  const char *getPluginNamespace() const TRT_NOEXCEPT override {
     return "torch2trt";
   }
 
@@ -256,30 +266,30 @@ class InterpolatePluginCreator : public IPluginCreator {
 public:
   InterpolatePluginCreator() {}
 
-  const char *getPluginNamespace() const noexcept override {
+  const char *getPluginNamespace() const TRT_NOEXCEPT override {
     return "torch2trt";
   }
 
-  const char *getPluginName() const noexcept override {
+  const char *getPluginName() const TRT_NOEXCEPT override {
     return "interpolate";
   }
 
-  const char *getPluginVersion() const noexcept override {
+  const char *getPluginVersion() const TRT_NOEXCEPT override {
     return "1";
   }
 
-  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) noexcept override {
+  IPluginV2 *deserializePlugin(const char *name, const void *data, size_t length) TRT_NOEXCEPT override {
     return new InterpolatePlugin((const char*) data, length);
   }
 
-  void setPluginNamespace(const char *N) noexcept override {}
-  const PluginFieldCollection *getFieldNames() noexcept override { return nullptr; }
+  void setPluginNamespace(const char *N) TRT_NOEXCEPT override {}
+  const PluginFieldCollection *getFieldNames() TRT_NOEXCEPT override { return nullptr; }
 
-  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) noexcept override { return nullptr; }
+  IPluginV2 *createPlugin(const char *name, const PluginFieldCollection *fc) TRT_NOEXCEPT override { return nullptr; }
 
 };
 
 
 REGISTER_TENSORRT_PLUGIN(InterpolatePluginCreator);
-    
+
 } // namespace torch2trt

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -576,7 +576,7 @@ def torch2trt(module,
                     inputs, int8_calib_dataset, batch_size=int8_calib_batch_size, algorithm=int8_calib_algorithm
                 )
         
-    engine = builder.build_cuda_engine(network)
+    engine = builder.build_engine(network)
 
     module_trt = TRTModule(engine, input_names, output_names)
 

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -555,10 +555,11 @@ def torch2trt(module,
                 outputs = (outputs,)
             ctx.mark_outputs(outputs, output_names)
 
-    builder.max_workspace_size = max_workspace_size
-    builder.fp16_mode = fp16_mode
+    config = builder.create_builder_config()
+    config.max_workspace_size = max_workspace_size
+    config.flags = fp16_mode << int(trt.BuilderFlag.FP16)
+    config.flags = strict_type_constraints << int(trt.BuilderFlag.STRICT_TYPES)
     builder.max_batch_size = max_batch_size
-    builder.strict_type_constraints = strict_type_constraints
 
     if int8_mode:
 
@@ -570,10 +571,10 @@ def torch2trt(module,
         
         #Making sure not to run calibration with QAT mode on 
         if not 'qat_mode' in kwargs:
-        # @TODO(jwelsh):  Should we set batch_size=max_batch_size?  Need to investigate memory consumption
-            builder.int8_calibrator = DatasetCalibrator(
-                inputs, int8_calib_dataset, batch_size=int8_calib_batch_size, algorithm=int8_calib_algorithm
-            )
+            # @TODO(jwelsh):  Should we set batch_size=max_batch_size?  Need to investigate memory consumption
+                builder.int8_calibrator = DatasetCalibrator(
+                    inputs, int8_calib_dataset, batch_size=int8_calib_batch_size, algorithm=int8_calib_algorithm
+                )
         
     engine = builder.build_cuda_engine(network)
 

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -576,7 +576,7 @@ def torch2trt(module,
                     inputs, int8_calib_dataset, batch_size=int8_calib_batch_size, algorithm=int8_calib_algorithm
                 )
         
-    engine = builder.build_engine(network)
+    engine = builder.build_engine(network, config)
 
     module_trt = TRTModule(engine, input_names, output_names)
 


### PR DESCRIPTION
- Update plugin classes to match the base IPluginV2 class in TensorRT8
- Cherry-pick from gcunhase/torch2trt
- Cherry-pick from gcunhase/torch2trt
- Cherry-pick from gcunhase/torch2trt
- Fix merge errors