### PR TITLE
Use common helper function set_layer_precision instead of private one for converters.

### DIFF
--- a/torch2trt/converters/clone.py
+++ b/torch2trt/converters/clone.py
@@ -2,27 +2,6 @@ from torch2trt.torch2trt import *
 from torch2trt.module_test import add_module_test
 
 
-def _set_layer_precision(ctx, layer):
-    # Supported TRT precisions as given by torch2trt_kwargs.
-    INT8_MODE = "int8_mode"
-    FP16_MODE = "fp16_mode"
-
-    # Check that args exist as expected in torch2trt_kwargs.
-    trt_kwargs = ctx.torch2trt_kwargs
-    assert INT8_MODE in trt_kwargs
-    assert FP16_MODE in trt_kwargs
-
-    is_int8 = trt_kwargs.get(INT8_MODE, False)
-    is_fp16 = trt_kwargs.get(FP16_MODE, False)
-
-    if is_int8:
-        layer.precision = trt.int8
-        layer.set_output_type(0, trt.int8)
-    elif is_fp16:
-        layer.precision = trt.float16
-        layer.set_output_type(0, trt.float16)
-
-
 @tensorrt_converter('torch.clone')
 @tensorrt_converter('torch.Tensor.clone')
 def convert_clone(ctx):
@@ -31,7 +10,7 @@ def convert_clone(ctx):
 
     # Clone by making identity layer.
     layer = ctx.network.add_identity(input_trt)
-    _set_layer_precision(ctx, layer)
+    set_layer_precision(ctx, layer)
 
     output = ctx.method_return
     output._trt = layer.get_output(0)


### PR DESCRIPTION
Several converters were using `_set_layer_precision`, which was a stand-in while a common one could be landed. Since the common one landed, we can now use that function instead of having to copy a private version for each converter. The common `set_layer_precision` can be found in `torch2trt.py`. 
