### PR TITLE
Add torch.Tensor.transpose converter

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@ who have agreed to torch2trt's Contributor License Agreement.
 
 - [John Welsh](https://github.com/jaybdub) (CLA)
 - John Welsh
+- [Eunseop Shin](https://github.com/kairos03) (CLA)
 
 ## Becoming a Contributor
 

--- a/torch2trt/converters/transpose.py
+++ b/torch2trt/converters/transpose.py
@@ -3,6 +3,7 @@ from torch2trt.module_test import add_module_test
 
 
 @tensorrt_converter("torch.transpose", enabled=trt_version() < '7.0')
+@tensorrt_converter("torch.Tensor.transpose", enabled=trt_version() < '7.0')
 def convert_transpose(ctx):
     input = ctx.method_args[0]
     input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
@@ -19,6 +20,7 @@ def convert_transpose(ctx):
 
 
 @tensorrt_converter('torch.transpose', enabled=trt_version() >= '7.0')
+@tensorrt_converter('torch.Tensor.transpose', enabled=trt_version() >= '7.0')
 def convert_transpose_trt7(ctx):
     input = ctx.method_args[0]
     input_trt = add_missing_trt_tensors(ctx.network, [input])[0]


### PR DESCRIPTION
torch.Tensor.transpose converter is missed.
I just add the annotation to link torch.Tensor.transpose and torch.transpose