### PR TITLE
[torch2trt/converters] Add support for single tensor only input arguments for `torch.max` and `torch.min`

### DIFF
--- a/torch2trt/converters/max.py
+++ b/torch2trt/converters/max.py
@@ -11,18 +11,21 @@ def __convert_max_elementwise(ctx):
     input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], len(output.shape))
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, trt.ElementWiseOperation.MAX)
     output._trt = layer.get_output(0)
-    
+
 
 def __convert_max_reduce(ctx):
     input = ctx.method_args[0]
     dim = get_arg(ctx, 'dim', pos=1, default=tuple(range(1, len(input.shape))))
     keepdim = get_arg(ctx, 'keepdim', pos=2, default=False)
     input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
-    output_val = ctx.method_return[0]
-    output_idx = ctx.method_return[1]
+    if isinstance(ctx.method_return, torch.Tensor):
+        output_val = ctx.method_return
+    else:
+        output_val = ctx.method_return[0]
+        output_idx = ctx.method_return[1]
     layer = ctx.network.add_reduce(input_trt,  trt.ReduceOperation.MAX, torch_dim_to_trt_axes(dim), keepdim)
     output_val._trt = layer.get_output(0)
-    
+
 
 @tensorrt_converter('torch.max')
 @tensorrt_converter('torch.Tensor.max')
@@ -31,7 +34,13 @@ def convert_max(ctx):
         __convert_max_elementwise(ctx)
     else:
         __convert_max_reduce(ctx)
-        
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3)])
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
+def test_max():
+    return UnaryModule(lambda x: torch.max(x))
+
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3)])
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
@@ -53,8 +62,8 @@ def test_max_reduce_dim1_keepdim():
 class MaxElementwise(torch.nn.Module):
     def forward(self, x, y):
         return torch.max(x, y)
-    
-    
+
+
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3), (1, 3, 3)])
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3), (1,)]) # broadcast
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3, 3), (1, 3, 3)]) # broadcast

--- a/torch2trt/converters/max.py
+++ b/torch2trt/converters/max.py
@@ -15,7 +15,7 @@ def __convert_max_elementwise(ctx):
 
 def __convert_max_reduce(ctx):
     input = ctx.method_args[0]
-    dim = get_arg(ctx, 'dim', pos=1, default=tuple(range(1, len(input.shape))))
+    dim = get_arg(ctx, 'dim', pos=1, default=tuple(range(0, len(input.shape))))
     keepdim = get_arg(ctx, 'keepdim', pos=2, default=False)
     input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     if isinstance(ctx.method_return, torch.Tensor):
@@ -38,8 +38,10 @@ def convert_max(ctx):
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3)])
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
+@add_module_test(torch.float32, torch.device('cuda'), [(3, 3, 3)])
 def test_max():
-    return UnaryModule(lambda x: torch.max(x))
+    # Can't exit the network with a 0D tensor so we unsqueeze a dim.
+    return UnaryModule(lambda x: torch.max(x).unsqueeze(0))
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3)])

--- a/torch2trt/converters/min.py
+++ b/torch2trt/converters/min.py
@@ -15,7 +15,7 @@ def __convert_min_elementwise(ctx):
 
 def __convert_min_reduce(ctx):
     input = ctx.method_args[0]
-    dim = get_arg(ctx, 'dim', pos=1, default=tuple(range(1,len(input.shape))))
+    dim = get_arg(ctx, 'dim', pos=1, default=tuple(range(0, len(input.shape))))
     keepdim = get_arg(ctx, 'keepdim', pos=2, default=False)
     input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
     if isinstance(ctx.method_return, torch.Tensor):
@@ -38,8 +38,10 @@ def convert_min(ctx):
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3)])
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
+@add_module_test(torch.float32, torch.device('cuda'), [(3, 3, 3)])
 def test_min():
-    return UnaryModule(lambda x: torch.min(x))
+    # Can't exit the network with a 0D tensor so we unsqueeze a dim.
+    return UnaryModule(lambda x: torch.min(x).unsqueeze(0))
 
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3)])

--- a/torch2trt/converters/min.py
+++ b/torch2trt/converters/min.py
@@ -11,18 +11,21 @@ def __convert_min_elementwise(ctx):
     input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], len(output.shape))
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, trt.ElementWiseOperation.MIN)
     output._trt = layer.get_output(0)
-    
+
 
 def __convert_min_reduce(ctx):
     input = ctx.method_args[0]
     dim = get_arg(ctx, 'dim', pos=1, default=tuple(range(1,len(input.shape))))
     keepdim = get_arg(ctx, 'keepdim', pos=2, default=False)
     input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
-    output_val = ctx.method_return[0]
-    output_idx = ctx.method_return[1]
+    if isinstance(ctx.method_return, torch.Tensor):
+        output_val = ctx.method_return
+    else:
+        output_val = ctx.method_return[0]
+        output_idx = ctx.method_return[1]
     layer = ctx.network.add_reduce(input_trt,  trt.ReduceOperation.MIN, torch_dim_to_trt_axes(dim), keepdim)
     output_val._trt = layer.get_output(0)
-    
+
 
 @tensorrt_converter('torch.min')
 @tensorrt_converter('torch.Tensor.min')
@@ -31,7 +34,13 @@ def convert_min(ctx):
         __convert_min_elementwise(ctx)
     else:
         __convert_min_reduce(ctx)
-        
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3)])
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
+def test_min():
+    return UnaryModule(lambda x: torch.min(x))
+
 
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3)])
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3)])
@@ -53,8 +62,8 @@ def test_min_reduce_dim1_keepdim():
 class MinElementwise(torch.nn.Module):
     def forward(self, x, y):
         return torch.min(x, y)
-    
-    
+
+
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3), (1, 3, 3)])
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3), (1,)]) # broadcast
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 3, 3), (1, 3, 3)]) # broadcast


### PR DESCRIPTION
**Description** 
This PR resolves the issue where `torch.max` and `torch.min` do not correctly convert if they're given only a single tensor input, which is a common use case. 

Addresses issue https://github.com/NVIDIA-AI-IOT/torch2trt/issues/677

**Tests**
See additional unit tests for `torch.max` and `torch.min`:
```
|                                      torch2trt.converters.max.test_max | float32 |               [(3, 3, 3)] | {} | 0.00E+00 | nan | 0.00E+00 | 7.72e+04 | 1.51e+04 | 0.0301 | 0.0838 |
|                                      torch2trt.converters.max.test_max | float32 |               [(1, 3, 3)] | {} | 0.00E+00 | nan | 0.00E+00 | 7.81e+04 | 1.52e+04 | 0.03 | 0.0831 |
|                                      torch2trt.converters.max.test_max | float32 |                  [(1, 3)] | {} | 0.00E+00 | nan | 0.00E+00 | 7.8e+04 | 1.52e+04 | 0.0299 | 0.0831 |
...
NUM_TESTS: 19
NUM_SUCCESSFUL_CONVERSION: 19
NUM_FAILED_CONVERSION: 0
NUM_ABOVE_TOLERANCE: 0
NUM_pSNR_TOLERANCE: 0
```
```
~/workspace/torch2trt (chaoz/torch-max-min-single-tensor) $ python -m torch2trt.test --name test_min
|                                      torch2trt.converters.min.test_min | float32 |               [(3, 3, 3)] | {} | 0.00E+00 | nan | 0.00E+00 | 7.84e+04 | 1.51e+04 | 0.0298 | 0.0839 |
|                                      torch2trt.converters.min.test_min | float32 |               [(1, 3, 3)] | {} | 0.00E+00 | nan | 0.00E+00 | 7.84e+04 | 1.51e+04 | 0.0296 | 0.0831 |
|                                      torch2trt.converters.min.test_min | float32 |                  [(1, 3)] | {} | 0.00E+00 | nan | 0.00E+00 | 7.9e+04 | 1.51e+04 | 0.0298 | 0.0838 |
...
NUM_TESTS: 11
NUM_SUCCESSFUL_CONVERSION: 11
NUM_FAILED_CONVERSION: 0
NUM_ABOVE_TOLERANCE: 0
NUM_pSNR_TOLERANCE: 0
```
