### PR TITLE
[converters/stack.py] Update stack converter to support dynamic shapes. Resolves #830.

### DIFF
--- a/torch2trt/converters/stack.py
+++ b/torch2trt/converters/stack.py
@@ -3,10 +3,11 @@ from torch2trt.module_test import add_module_test
 
 
 def unsqueeze(ctx, input, dim):
-    layer = ctx.network.add_shuffle(trt_(ctx.network, input))
+    shape = input.shape[:dim] + (make_int_wrapper(1),) + input.shape[dim:]
+    shape_trt = make_size_wrapper(shape)._trt
 
-    shape = input.shape[:dim] + (1,) + input.shape[dim:]
-    layer.reshape_dims = tuple(shape)
+    layer = ctx.network.add_shuffle(trt_(ctx.network, input))
+    layer.set_input(1, shape_trt)
 
     return layer.get_output(0)
 

--- a/torch2trt/converters/stack_test.py
+++ b/torch2trt/converters/stack_test.py
@@ -1,0 +1,28 @@
+import torch
+import torch2trt
+
+torch.manual_seed(0)
+
+
+class StackModule(torch.nn.Module):
+    def forward(self, a):
+        return torch.stack((a, a))
+
+
+def test_stack_dynamic():
+    tensor = torch.rand((2, 2)).cuda()
+
+    model = StackModule().eval().cuda()
+    model_trt = torch2trt.torch2trt(
+        model, [tensor], min_shapes=[(1, 1)], max_shapes=[(5, 5)]
+    )
+
+    assert torch.allclose(model(tensor), model_trt(tensor))
+
+    tensor = torch.rand((5, 5)).cuda()
+    assert torch.allclose(model(tensor), model_trt(tensor))
+
+
+if __name__ == "__main__":
+    test_stack_dynamic()
+


### PR DESCRIPTION
Resolves issue #830, where `torch.stack` does not currently correctly handle dynamic shapes during TRT conversion.

Checked with included test:
```
python torch2trt/converters/stack_test.py
```