### PR TITLE
[torch2trt/torch2trt.py] Add configuration for avg timing iterations.

### DIFF
--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -673,6 +673,7 @@ def torch2trt(module,
               opt_shapes=None,
               onnx_opset=None,
               max_batch_size=None,
+              avg_timing_iterations=None,
               **kwargs):
 
     # capture arguments to provide to context
@@ -782,6 +783,10 @@ def torch2trt(module,
 
     # set max workspace size
     config.max_workspace_size = max_workspace_size
+
+    # set number of avg timing itrs.
+    if avg_timing_iterations is not None:
+        config.avg_timing_iterations = avg_timing_iterations
 
     if fp16_mode:
         config.set_flag(trt.BuilderFlag.FP16)


### PR DESCRIPTION
This is a PR to expose the `avg_timing_iterations` option configuration explained [under Increasing Average Timing Iterations here](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#deterministic-tactic-selection).

We've noticed with the recent TRT upgrade that occasionally tactics may be selected on certain GPUs (specifically T4s), resulting in outputs with significantly less significant figures of precision. This also results in less determinism when building TRT engines.

We expose the `avg_timing_iterations` config so that users can increase the number of timing iterations as needed to restore determinism and reduce the likelihood picking less than optimal tactics. 