### PR TITLE
[converters/compare.py] Fix issue #838 comparing tensors to scalars

### DIFF
--- a/torch2trt/converters/compare.py
+++ b/torch2trt/converters/compare.py
@@ -6,7 +6,7 @@ def convert_elementwise(ctx, op):
     input_b = ctx.method_args[1]
     output = ctx.method_return
     input_a_trt, input_b_trt = add_missing_trt_tensors(ctx.network, [input_a, input_b])
-    input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], len(output.shape) - 1)
+    input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], max(len(input_a_trt.shape), len(input_b_trt.shape)))
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, op)
     output._trt = layer.get_output(0)
 
@@ -58,3 +58,87 @@ def test_gt_basic():
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 6, 6), (1, 3, 6, 6)], enabled=trt_version() >= '7.0')
 def test_gt_basic():
     return EQ()
+
+
+class TensorGTScalar(torch.nn.Module):
+    def __init__(self, scalar):
+        super().__init__()
+        self.scalar = scalar
+
+    def forward(self, tensor):
+        return tensor > self.scalar
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 6, 6)], enabled=trt_version() >= '7.0')
+def test_tensor_gt_scalar():
+    return TensorGTScalar(0.1)
+
+
+class ScalarGTTensor(torch.nn.Module):
+    def __init__(self, scalar):
+        super().__init__()
+        self.scalar = scalar
+
+    def forward(self, tensor):
+        return self.scalar > tensor
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 6, 6)], enabled=trt_version() >= '7.0')
+def test_scalar_gt_scalar():
+    return ScalarGTTensor(0.1)
+
+
+class TensorLTScalar(torch.nn.Module):
+    def __init__(self, scalar):
+        super().__init__()
+        self.scalar = scalar
+
+    def forward(self, tensor):
+        return tensor < self.scalar
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 6, 6)], enabled=trt_version() >= '7.0')
+def test_tensor_lt_scalar():
+    return TensorLTScalar(0.1)
+
+
+class ScalarLTTensor(torch.nn.Module):
+    def __init__(self, scalar):
+        super().__init__()
+        self.scalar = scalar
+
+    def forward(self, tensor):
+        return self.scalar < tensor
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 6, 6)], enabled=trt_version() >= '7.0')
+def test_scalar_lt_tensor():
+    return ScalarLTTensor(0.1)
+
+
+class TensorEQScalar(torch.nn.Module):
+    def __init__(self, scalar):
+        super().__init__()
+        self.scalar = scalar
+
+    def forward(self, tensor):
+        return tensor == self.scalar
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 6, 6)], enabled=trt_version() >= '7.0')
+def test_tensor_eq_scalar():
+    return TensorEQScalar(0.1)
+
+
+class ScalarEQTensor(torch.nn.Module):
+    def __init__(self, scalar):
+        super().__init__()
+        self.scalar = scalar
+
+    def forward(self, tensor):
+        return self.scalar == tensor
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 6, 6)], enabled=trt_version() >= '7.0')
+def test_scalar_eq_tensor():
+    return ScalarEQTensor(0.1)


### PR DESCRIPTION
Addresses issue https://github.com/NVIDIA-AI-IOT/torch2trt/issues/838.

Comparing torch.Tensor to scalars currently fails due to how broadcast shapes are calculated when comparing against scalars. 

Unit test:
```
|                             torch2trt.converters.compare.test_gt_basic | float32 | [(1, 3, 6, 6), (1, 3, 6, 6)] | {} | 0.00E+00 | nan | NAN | 1.16e+05 | 1.37e+04 | 0.0174 | 0.0863 |
|                             torch2trt.converters.compare.test_gt_basic | float32 | [(1, 3, 6, 6), (1, 3, 6, 6)] | {} | 0.00E+00 | nan | NAN | 1.14e+05 | 1.42e+04 | 0.0179 | 0.0833 |
|                             torch2trt.converters.compare.test_gt_basic | float32 | [(1, 3, 6, 6), (1, 3, 6, 6)] | {} | 0.00E+00 | nan | NAN | 1.25e+05 | 1.4e+04 | 0.0173 | 0.0838 |
|                     torch2trt.converters.compare.test_tensor_gt_scalar | float32 |            [(1, 3, 6, 6)] | {} | 0.00E+00 | nan | NAN | 9.31e+04 | 1.52e+04 | 0.021 | 0.0785 |
|                     torch2trt.converters.compare.test_scalar_gt_scalar | float32 |            [(1, 3, 6, 6)] | {} | 0.00E+00 | nan | NAN | 9.57e+04 | 1.49e+04 | 0.0216 | 0.08 |
|                     torch2trt.converters.compare.test_tensor_lt_scalar | float32 |            [(1, 3, 6, 6)] | {} | 0.00E+00 | nan | NAN | 9.86e+04 | 1.55e+04 | 0.0208 | 0.0768 |
|                     torch2trt.converters.compare.test_scalar_lt_tensor | float32 |            [(1, 3, 6, 6)] | {} | 0.00E+00 | nan | NAN | 9.15e+04 | 1.54e+04 | 0.0209 | 0.0776 |
|                     torch2trt.converters.compare.test_tensor_eq_scalar | float32 |            [(1, 3, 6, 6)] | {} | 0.00E+00 | nan | NAN | 1.01e+05 | 1.52e+04 | 0.0209 | 0.0761 |
|                     torch2trt.converters.compare.test_scalar_eq_tensor | float32 |            [(1, 3, 6, 6)] | {} | 0.00E+00 | nan | NAN | 1.01e+05 | 1.51e+04 | 0.0194 | 0.0769 |
NUM_TESTS: 9
NUM_SUCCESSFUL_CONVERSION: 9
NUM_FAILED_CONVERSION: 0
NUM_ABOVE_TOLERANCE: 0
NUM_pSNR_TOLERANCE: 0
```