### PR TITLE
[converters/squeeze.py] Address issue #841 where torch.squeeze does not correctly handle negative dimensions.

### DIFF
--- a/torch2trt/converters/squeeze.py
+++ b/torch2trt/converters/squeeze.py
@@ -12,6 +12,10 @@ def convert_squeeze(ctx):
     output = ctx.method_return
     dim = get_arg(ctx, 'dim', pos=1, default=None)
 
+    if dim < 0:
+        dim = len(input.shape) + dim
+    assert dim >= 0
+
     input_trt = add_missing_trt_tensors(ctx.network, [input])[0]
 
     input_shape_trt = ctx.network.add_shape(input_trt).get_output(0)
@@ -46,4 +50,12 @@ class Squeeze(torch.nn.Module):
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 1, 3)])
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 1, 3)], max_batch_size=2)
 def test_squeeze():
-    return Squeeze(2)    
+    return Squeeze(2)
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 1, 1)])
+def test_squeeze_neg():
+    return Squeeze(-1)
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 1, 1)])
+def test_squeeze_neg2():
+    return Squeeze(-2)


### PR DESCRIPTION
Addresses issue #841.

This PR adds negative dimension handling when squeezing.

Unit tests:
```
|                              torch2trt.converters.squeeze.test_squeeze | float32 |            [(1, 3, 1, 3)] | {'max_batch_size': 2} | 0.00E+00 | nan | 0.00E+00 | 2.85e+05 | 1.65e+04 | 0.0109 | 0.0716 |
|                              torch2trt.converters.squeeze.test_squeeze | float32 |            [(1, 3, 1, 3)] | {} | 0.00E+00 | nan | 0.00E+00 | 3.28e+05 | 1.68e+04 | 0.0119 | 0.0712 |
|                              torch2trt.converters.squeeze.test_squeeze | float32 |               [(1, 3, 1)] | {} | 0.00E+00 | nan | 0.00E+00 | 3.29e+05 | 1.72e+04 | 0.0111 | 0.069 |
|                          torch2trt.converters.squeeze.test_squeeze_neg | float32 |            [(1, 3, 1, 1)] | {} | 0.00E+00 | nan | 0.00E+00 | 2.63e+05 | 1.67e+04 | 0.011 | 0.071 |
|                         torch2trt.converters.squeeze.test_squeeze_neg2 | float32 |            [(1, 3, 1, 1)] | {} | 0.00E+00 | nan | 0.00E+00 | 3.17e+05 | 1.67e+04 | 0.012 | 0.0689 |
|                          torch2trt.converters.unsqueeze.test_unsqueeze | float32 |            [(1, 3, 1, 3)] | {'max_batch_size': 2} | 0.00E+00 | nan | 0.00E+00 | 3.34e+05 | 1.67e+04 | 0.0109 | 0.0718 |
|                          torch2trt.converters.unsqueeze.test_unsqueeze | float32 |            [(1, 3, 5, 3)] | {} | 0.00E+00 | nan | 0.00E+00 | 3.32e+05 | 1.61e+04 | 0.0112 | 0.0726 |
|                          torch2trt.converters.unsqueeze.test_unsqueeze | float32 |                  [(1, 7)] | {} | 0.00E+00 | nan | 0.00E+00 | 3.42e+05 | 1.73e+04 | 0.0114 | 0.0686 |
NUM_TESTS: 8
NUM_SUCCESSFUL_CONVERSION: 8
NUM_FAILED_CONVERSION: 0
NUM_ABOVE_TOLERANCE: 0
NUM_pSNR_TOLERANCE: 0
```