### PR TITLE
[torch2trt/torch2trt.py] Resolve issue #846: Add support for using `._trt` when encountering an IntWrapper scalar. 

### DIFF
--- a/torch2trt/converters/compare.py
+++ b/torch2trt/converters/compare.py
@@ -6,7 +6,7 @@ def convert_elementwise(ctx, op):
     input_b = ctx.method_args[1]
     output = ctx.method_return
     input_a_trt, input_b_trt = add_missing_trt_tensors(ctx.network, [input_a, input_b])
-    input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], len(output.shape) - 1)
+    input_a_trt, input_b_trt = broadcast_trt_tensors(ctx.network, [input_a_trt, input_b_trt], max(len(input_a_trt.shape), len(input_b_trt.shape)))
     layer = ctx.network.add_elementwise(input_a_trt, input_b_trt, op)
     output._trt = layer.get_output(0)
 
@@ -58,3 +58,87 @@ def test_gt_basic():
 @add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 6, 6), (1, 3, 6, 6)], enabled=trt_version() >= '7.0')
 def test_gt_basic():
     return EQ()
+
+
+class TensorGTScalar(torch.nn.Module):
+    def __init__(self, scalar):
+        super().__init__()
+        self.scalar = scalar
+
+    def forward(self, tensor):
+        return tensor > self.scalar
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 6, 6)], enabled=trt_version() >= '7.0')
+def test_tensor_gt_scalar():
+    return TensorGTScalar(0.1)
+
+
+class ScalarGTTensor(torch.nn.Module):
+    def __init__(self, scalar):
+        super().__init__()
+        self.scalar = scalar
+
+    def forward(self, tensor):
+        return self.scalar > tensor
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 6, 6)], enabled=trt_version() >= '7.0')
+def test_scalar_gt_scalar():
+    return ScalarGTTensor(0.1)
+
+
+class TensorLTScalar(torch.nn.Module):
+    def __init__(self, scalar):
+        super().__init__()
+        self.scalar = scalar
+
+    def forward(self, tensor):
+        return tensor < self.scalar
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 6, 6)], enabled=trt_version() >= '7.0')
+def test_tensor_lt_scalar():
+    return TensorLTScalar(0.1)
+
+
+class ScalarLTTensor(torch.nn.Module):
+    def __init__(self, scalar):
+        super().__init__()
+        self.scalar = scalar
+
+    def forward(self, tensor):
+        return self.scalar < tensor
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 6, 6)], enabled=trt_version() >= '7.0')
+def test_scalar_lt_tensor():
+    return ScalarLTTensor(0.1)
+
+
+class TensorEQScalar(torch.nn.Module):
+    def __init__(self, scalar):
+        super().__init__()
+        self.scalar = scalar
+
+    def forward(self, tensor):
+        return tensor == self.scalar
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 6, 6)], enabled=trt_version() >= '7.0')
+def test_tensor_eq_scalar():
+    return TensorEQScalar(0.1)
+
+
+class ScalarEQTensor(torch.nn.Module):
+    def __init__(self, scalar):
+        super().__init__()
+        self.scalar = scalar
+
+    def forward(self, tensor):
+        return self.scalar == tensor
+
+
+@add_module_test(torch.float32, torch.device('cuda'), [(1, 3, 6, 6)], enabled=trt_version() >= '7.0')
+def test_scalar_eq_tensor():
+    return ScalarEQTensor(0.1)

--- a/torch2trt/torch2trt.py
+++ b/torch2trt/torch2trt.py
@@ -153,12 +153,12 @@ def add_missing_trt_tensors(network, tensors):
 
             # get tensor w/ _trt
             # or... add constant for scalar primitive
-            if isinstance(t, float) or isinstance(t, int):
+            if hasattr(t, "_trt") or isinstance(t, IntWrapper):
+                trt_tensor = t._trt
+            elif isinstance(t, float) or isinstance(t, int):
                 shape = (1,)
                 scalar = t * torch.ones(shape, dtype=dtype).cpu().numpy()
                 trt_tensor = network.add_constant(shape, scalar).get_output(0)
-            elif hasattr(t, "_trt"):
-                trt_tensor = t._trt
 
             # or... add constant for leaf tensor w/o _trt
             else:
@@ -232,7 +232,7 @@ def trt_(network, *tensors):
             # GET TRT TENSOR (OR CREATE TRT CONSTANT)
 
             # get tensor w/ _trt
-            if isinstance(t, torch.Tensor) and hasattr(t, "_trt"):
+            if (isinstance(t, torch.Tensor) and hasattr(t, "_trt")) or isinstance(t, IntWrapper):
                 trt_tensor = t._trt
 
             # or... add constant for leaf tensor w/o _trt


### PR DESCRIPTION
Resolves issue #846.

Depends on PR #839. 

When encountering an IntWrapper for inputs, we currently treat these as normal scalars, ignoring that they already have a `._trt` attribute. This is both wrong and results in issues when trying to add the scalar as a constant layer to the network. This PR addresses this issue. 

Running the script in #846:
```
  import logging
  import tensorrt
  import torch
  import torch2trt

  from typing import List


  logging.basicConfig(level=logging.INFO)
  torch.manual_seed(0)


  class Module(torch.nn.Module):
      def forward(self, t: torch.Tensor) -> List[torch.Tensor]:
          h, w = t.shape
          return [t < float(h)]


  if __name__ == "__main__":
      tensor = torch.rand(3, 3).cuda()

      model = Module().cuda().eval()
      out = model(tensor).pop()
      print(f"Out {out}")

      model_trt = torch2trt.torch2trt(
          model, [tensor], log_level=tensorrt.Logger.INFO, min_shapes=[(1,1)], max_shapes=[(10,10)]
      )
      out_trt = model_trt(tensor).pop()
      print(f"Out TRT {out_trt}")

      assert torch.allclose(out, out_trt), "Not all close!"
      print("All close!")

      tensor = torch.rand(3,3).cuda()

      out = model(tensor).pop()
      out_trt = model_trt(tensor).pop()

      assert torch.allclose(out, out_trt), "Not all close!"
      print("All close!")
```
with this change applied now outputs the following:
```
Out tensor([[True, True, True],
        [True, True, True],
        [True, True, True]], device='cuda:0')
[02/14/2023-19:32:26] [TRT] [I] [MemUsageChange] Init CUDA: CPU +3, GPU +0, now: CPU 696, GPU 354 (MiB)
[02/14/2023-19:32:28] [TRT] [I] [MemUsageChange] Init builder kernel library: CPU +447, GPU +120, now: CPU 1197, GPU 474 (MiB)
[02/14/2023-19:32:28] [TRT] [W] Tensor DataType is determined at build time for tensors not marked as input or output.
[02/14/2023-19:32:28] [TRT] [I] [MemUsageChange] Init cuBLAS/cuBLASLt: CPU +839, GPU +338, now: CPU 2036, GPU 812 (MiB)
[02/14/2023-19:32:29] [TRT] [I] [MemUsageChange] Init cuDNN: CPU +129, GPU +58, now: CPU 2165, GPU 870 (MiB)
[02/14/2023-19:32:29] [TRT] [W] TensorRT was linked against cuDNN 8.6.0 but loaded cuDNN 8.4.0
[02/14/2023-19:32:29] [TRT] [I] Local timing cache in use. Profiling results in this builder pass will not be stored.
[02/14/2023-19:32:29] [TRT] [W] Myelin graph with multiple dynamic values may have poor performance if they differ. Dynamic values are:
[02/14/2023-19:32:29] [TRT] [W]  (# 1 (SHAPE input_0))
[02/14/2023-19:32:29] [TRT] [W]  (# 0 (SHAPE input_0))
[02/14/2023-19:32:30] [TRT] [I] Total Activation Memory: 33555456
[02/14/2023-19:32:30] [TRT] [I] Detected 1 inputs and 1 output network tensors.
[02/14/2023-19:32:30] [TRT] [W] Myelin graph with multiple dynamic values may have poor performance if they differ. Dynamic values are:
[02/14/2023-19:32:30] [TRT] [W]  (# 1 (SHAPE input_0))
[02/14/2023-19:32:30] [TRT] [W]  (# 0 (SHAPE input_0))
[02/14/2023-19:32:30] [TRT] [I] Total Host Persistent Memory: 160
[02/14/2023-19:32:30] [TRT] [I] Total Device Persistent Memory: 0
[02/14/2023-19:32:30] [TRT] [I] Total Scratch Memory: 1024
[02/14/2023-19:32:30] [TRT] [I] [MemUsageStats] Peak memory usage of TRT CPU/GPU memory allocators: CPU 0 MiB, GPU 4 MiB
[02/14/2023-19:32:30] [TRT] [I] [BlockAssignment] Started assigning block shifts. This will take 3 steps to complete.
[02/14/2023-19:32:30] [TRT] [I] [BlockAssignment] Algorithm ShiftNTopDown took 0.01238ms to assign 3 blocks to 3 nodes requiring 2048 bytes.
[02/14/2023-19:32:30] [TRT] [I] Total Activation Memory: 2048
[02/14/2023-19:32:30] [TRT] [I] [MemUsageChange] TensorRT-managed allocation in building engine: CPU +0, GPU +4, now: CPU 0, GPU 4 (MiB)
[02/14/2023-19:32:30] [TRT] [I] [MemUsageChange] TensorRT-managed allocation in IExecutionContext creation: CPU +0, GPU +0, now: CPU 0, GPU 4 (MiB)
Out TRT tensor([[True, True, True],
        [True, True, True],
        [True, True, True]], device='cuda:0')
All close!
All close!
```