### PR TITLE
Fixed TEST_OUTPUT.md table report (PSNR and MSE were not included in the table header)

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -4,7 +4,7 @@ OUTPUT_FILE=$1
 
 touch $OUTPUT_FILE
 
-echo "| Name | Data Type | Input Shapes | torch2trt kwargs | Max Error | Throughput (PyTorch) | Throughput (TensorRT) | Latency (PyTorch) | Latency (TensorRT) |" >> $OUTPUT_FILE
+echo "| Name | Data Type | Input Shapes | torch2trt kwargs | Max Error | PSNR | MSE | Throughput (PyTorch) | Throughput (TensorRT) | Latency (PyTorch) | Latency (TensorRT) |" >> $OUTPUT_FILE
 echo "|------|-----------|--------------|------------------|-----------|----------------------|-----------------------|-------------------|--------------------|" >> $OUTPUT_FILE
 
 python3 -m torch2trt.test -o $OUTPUT_FILE --name alexnet --include=torch2trt.tests.torchvision.classification

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@ OUTPUT_FILE=$1
 touch $OUTPUT_FILE
 
 echo "| Name | Data Type | Input Shapes | torch2trt kwargs | Max Error | PSNR | MSE | Throughput (PyTorch) | Throughput (TensorRT) | Latency (PyTorch) | Latency (TensorRT) |" >> $OUTPUT_FILE
-echo "|------|-----------|--------------|------------------|-----------|----------------------|-----------------------|-------------------|--------------------|" >> $OUTPUT_FILE
+echo "|------|-----------|--------------|------------------|-----------|------|-----|----------------------|-----------------------|-------------------|--------------------|" >> $OUTPUT_FILE
 
 python3 -m torch2trt.test -o $OUTPUT_FILE --name alexnet --include=torch2trt.tests.torchvision.classification
 python3 -m torch2trt.test -o $OUTPUT_FILE --name squeezenet1_0 --include=torch2trt.tests.torchvision.classification


### PR DESCRIPTION
PSNR and MSE are calculated in test.sh and included numerically in the report table at the outputted .md, but the corresponding headers were not included. This gives a very confusing result when visualizing the final table.