### PR TITLE
Update interpolate.py: Adds support for Python version >= 3.10

### DIFF
--- a/torch2trt/converters/interpolate.py
+++ b/torch2trt/converters/interpolate.py
@@ -3,6 +3,11 @@ import torch.nn as nn
 from torch2trt.torch2trt import *                                 
 from torch2trt.module_test import add_module_test
 import collections
+import sys
+if sys.version_info[0] == 3 and sys.version_info[1] >= 10:
+    import collections.abc as collections
+else:
+    import collections
 
 
 def has_interpolate_plugin():


### PR DESCRIPTION
Python deprecated collections.Sequence in favor of collections.abc.Sequence. The update checks for the Python version and uses collections.abc instead of collections for Python versions over 3.9