### PR TITLE
Support text models

### DIFF
--- a/torch2trt/flattener.py
+++ b/torch2trt/flattener.py
@@ -3,7 +3,7 @@ import torch
 
 
 def _default_condition(x):
-    return isinstance(x, torch.Tensor) and (x.dtype is torch.half or x.dtype is torch.float or x.dtype == torch.bool)
+    return isinstance(x, torch.Tensor) and (x.dtype is torch.half or x.dtype is torch.float or x.dtype == torch.bool or x.dtype == torch.int32 or x.dtype == torch.int64 or x.dtype == torch.long)
 
 
 def _make_schema_from_value(value, condition=_default_condition, size=0):

--- a/torch2trt/flattener.py
+++ b/torch2trt/flattener.py
@@ -3,7 +3,7 @@ import torch
 
 
 def _default_condition(x):
-    return isinstance(x, torch.Tensor) and (x.dtype is torch.half or x.dtype is torch.float or x.dtype == torch.bool or x.dtype == torch.int32 or x.dtype == torch.int64 or x.dtype == torch.long)
+    return isinstance(x, torch.Tensor) and (x.dtype is torch.half or x.dtype is torch.float or x.dtype == torch.bool or x.dtype == torch.int32 or x.dtype == torch.int64 or x.dtype == torch.long)
 
 
 def _make_schema_from_value(value, condition=_default_condition, size=0):


### PR DESCRIPTION
Because how flattener limits to floats as inputs, it will wrongly remove any int inputs that are common in text models e.g. encoded token ids.

Discovered when trying to convert a text transformer for SigLIP in https://github.com/NVIDIA-AI-IOT/torch2trt/issues/931

Closes https://github.com/NVIDIA-AI-IOT/torch2trt/issues/931

Tested with SigLIP and results matches closely,